### PR TITLE
hotfix for per plan parameter

### DIFF
--- a/src/SaaS.SDK.CustomerProvisioning/WebHook/WebhookHandler.cs
+++ b/src/SaaS.SDK.CustomerProvisioning/WebHook/WebhookHandler.cs
@@ -176,9 +176,28 @@ namespace Microsoft.Marketplace.SaaS.SDK.Services.WebHook
         /// Change QuantityAsync.
         /// </returns>
         /// <exception cref="NotImplementedException"> Exception.</exception>
-        public Task ChangeQuantityAsync(WebhookPayload payload)
+        public async Task ChangeQuantityAsync(WebhookPayload payload)
         {
-            throw new NotImplementedException();
+            var oldValue = this.subscriptionService.GetSubscriptionsBySubscriptionId(payload.SubscriptionId);
+
+            this.subscriptionService.UpdateSubscriptionQuantity(payload.SubscriptionId, payload.Quantity);
+            this.applicationLogService.AddApplicationLog("Plan Quantity Successfully Changed.");
+
+            if (oldValue != null)
+            {
+                SubscriptionAuditLogs auditLog = new SubscriptionAuditLogs()
+                {
+                    Attribute = Convert.ToString(SubscriptionLogAttributes.Quantity),
+                    SubscriptionId = oldValue.SubscribeId,
+                    NewValue = payload.Quantity.ToString(),
+                    OldValue = oldValue.Quantity.ToString(),
+                    CreateBy = null,
+                    CreateDate = DateTime.Now,
+                };
+                this.subscriptionsLogRepository.Save(auditLog);
+            }
+
+            await Task.CompletedTask;
         }
 
         /// <summary>

--- a/src/SaaS.SDK.Services/Services/FulfillmentApiService.cs
+++ b/src/SaaS.SDK.Services/Services/FulfillmentApiService.cs
@@ -197,7 +197,7 @@ namespace Microsoft.Marketplace.SaaS.SDK.Services.Services
             {
                 try 
                 { 
-                    var operationId = await this.marketplaceClient.Fulfillment.UpdateSubscriptionAsync(subscriptionId, new SubscriberPlan { PlanId = "" });
+                    var operationId = await this.marketplaceClient.Fulfillment.UpdateSubscriptionAsync(subscriptionId, new SubscriberPlan { Quantity = subscriptionQuantity });
                     return new SubscriptionUpdateResult() { OperationIdFromClientLib = operationId };
                 }
                 catch (RequestFailedException ex)


### PR DESCRIPTION
In this hotfix, 
- Update ChangeQuantityAsync method to process changed Quantity instead of passing blanked PlanID
- Update webhook to process the change if it was triggered from other resources.
