### PR TITLE
Add Back button to Application Config Details page

### DIFF
--- a/src/SaaS.SDK.PublisherSolution/Views/ApplicationConfig/ApplicationConfigDetails.cshtml
+++ b/src/SaaS.SDK.PublisherSolution/Views/ApplicationConfig/ApplicationConfigDetails.cshtml
@@ -52,6 +52,7 @@
             </table>
             <div class="ac-save-d">
                 <p>
+                    <a class="cm-button-default mt0" id="backButton" asp-area="" asp-controller="ApplicationConfig" asp-action="Index">Back</a>
                     <input class="cm-button-default mt0 ac-save-i" type="button" onclick="saveAppConfigDetails()" value="Save App Config" />
                 </p>
             </div>


### PR DESCRIPTION
#177 

I considered naming the button "cancel" as suggested by the above mentioned ticket, but I noticed that the Save Action does not got back to the settings page either and user has to manually go back .

In this context, a back button might be more appropriate than a "cancel" as it could cause confusion if the user Saved before.