### PR TITLE
Fix Subscriptions table for publisher portal

### DIFF
--- a/src/SaaS.SDK.PublisherSolution/Views/Home/Subscriptions.cshtml
+++ b/src/SaaS.SDK.PublisherSolution/Views/Home/Subscriptions.cshtml
@@ -27,8 +27,7 @@
                             <table id="table" class="table table-bordered dt-responsive table-condensed cm-table mt20" width="100%">
                                 <thead class="cm-table-head">
                                     <tr>
-                                        <th>User Name</th>
-                                        <th>User Email</th>
+                                        <th>Purchaser Email</th>
                                         <th>Subscription Name</th>
                                         <th>Plan</th>
                                         <th>Quantity</th>
@@ -42,10 +41,7 @@
                                         var subscription = Model.Subscriptions[i];
                                         <tr>
                                             <td class="text-left">
-                                                @subscription.CustomerName
-                                            </td>
-                                            <td class="text-left">
-                                                @subscription.CustomerEmailAddress
+                                                @subscription.Purchaser.EmailId
                                             </td>
                                             <td class="text-left">
                                                 @Html.HiddenFor(s => s.Subscriptions[i].Id)

--- a/src/SaaS.SDK.Services/Services/SMTPEmailService.cs
+++ b/src/SaaS.SDK.Services/Services/SMTPEmailService.cs
@@ -48,7 +48,6 @@
 
                 if (!string.IsNullOrEmpty(emailContent.BCCEmails))
                 {
-                    string[] bccEmails = emailContent.BCCEmails.Split(';');
                     foreach (string multimailid1 in toEmails)
                     {
                         mail.Bcc.Add(new MailAddress(multimailid1));


### PR DESCRIPTION
Fixed Subscriptions table for publisher portal to use purchaser email instead of current user name and email. Removed unused variable.