### PR TITLE
appsettings.Development.json fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -362,4 +362,5 @@ src/.idea/.idea.Microsoft.Marketplace.SaaS.SDK/.idea/projectSettingsUpdater.xml
 src/.idea/.idea.Microsoft.Marketplace.SaaS.SDK/.idea/vcs.xml
 
 # ignoring developer settings file
-appsettings.Development.json
+src/SaaS.SDK.CustomerProvisioning/appsettings.Development.json
+src/SaaS.SDK.PublisherSolution/appsettings.Development.json

--- a/src/SaaS.SDK.CustomerProvisioning/appsettings.Development.json
+++ b/src/SaaS.SDK.CustomerProvisioning/appsettings.Development.json
@@ -1,9 +1,0 @@
-{
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft": "Warning",
-      "Microsoft.Hosting.Lifetime": "Information"
-    }
-  }
-}

--- a/src/SaaS.SDK.CustomerProvisioning/appsettings.Development.json.rename
+++ b/src/SaaS.SDK.CustomerProvisioning/appsettings.Development.json.rename
@@ -1,0 +1,28 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  // comment the sections - saasapiconfiguration and connection strings when deploying to azure
+  //"saasapiconfiguration": {
+
+  //  "granttype": "client_credentials",
+  //  "clientid": "",
+  //  "clientsecret": "",
+  //  "mtclientid": "",
+  //  "tenantid": "",
+  //  "resource": "20e940b3-4c77-4b0b-9a53-9e16a1b010a7",
+  //  "fulfillmentapibaseurl": "https://marketplaceapi.microsoft.com/api",
+  //  "signedoutredirecturi": "",
+  //  "fulfillmentapiversion": "2018-08-31",
+  //  "adauthenticationendpoint": "https://login.microsoftonline.com",
+  //  "saasappurl": ""
+  //},
+  //"connectionstrings": {
+  //  "defaultconnection": ""
+  //},
+  "AllowedHosts": "*"
+}

--- a/src/SaaS.SDK.PublisherSolution/appsettings.Development.json.rename
+++ b/src/SaaS.SDK.PublisherSolution/appsettings.Development.json.rename
@@ -1,0 +1,28 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  // comment the sections - saasapiconfiguration and connection strings when deploying to azure
+  //"saasapiconfiguration": {
+
+  //  "granttype": "client_credentials",
+  //  "tenantid": "",
+  //  "clientid": "",
+  //  "clientsecret": "",
+  //  "mtclientid": "",
+  //  "resource": "20e940b3-4c77-4b0b-9a53-9e16a1b010a7",
+  //  "fulfillmentapibaseurl": "https://marketplaceapi.microsoft.com/api",
+  //  "signedoutredirecturi": "",
+  //  "fulfillmentapiversion": "2018-08-31",
+  //  "adauthenticationendpoint": "https://login.microsoftonline.com",
+  //  "saasappurl": ""
+  //},
+  //"connectionstrings": {
+  //  "defaultconnection": ""
+  //},
+  "AllowedHosts": "*"
+}


### PR DESCRIPTION
When working on these projects, the appsettings.Development.json are being tracked by git and must be manually monitored so they aren't committed with secrets. Adding the files to .gitignore does not solve the issue as **files that are already tracked will not be ignored by .gitignore**.

After researching this issue with Santhosh, there seems to be no better solution than to include a template file to the repo that a dev can rename after cloning. Then the entries in .gitignore will actually ignore the Development files.