### PR TITLE
ActivationFailed to Activate Fix

### DIFF
--- a/src/SaaS.SDK.PublisherSolution/Views/Home/SubscriptionDetails.cshtml
+++ b/src/SaaS.SDK.PublisherSolution/Views/Home/SubscriptionDetails.cshtml
@@ -89,7 +89,7 @@
                     {
                         <button type="submit" asp-action="SubscriptionOperation" asp-route-subscriptionId="@Model.Id" asp-route-planId="@Model.PlanId" asp-route-operation="Deactivate" class="cm-button-danger text-right">Unsubscribe</button>
                     }
-                    @if (Model.SubscriptionStatus == SubscriptionStatusEnumExtension.PendingFulfillmentStart || Model.SubscriptionStatus == SubscriptionStatusEnumExtension.PendingActivation)
+                    @if (Model.SubscriptionStatus == SubscriptionStatusEnumExtension.PendingFulfillmentStart || Model.SubscriptionStatus == SubscriptionStatusEnumExtension.PendingActivation || Model.SubscriptionStatus == SubscriptionStatusEnumExtension.ActivationFailed)
                     {
                         <button type="submit" asp-action="SubscriptionOperation" asp-route-subscriptionId="@Model.Id" asp-route-planId="@Model.PlanId" asp-route-operation="Activate" class="cm-button-default mt40 text-right">Activate</button>
                     }

--- a/src/SaaS.SDK.PublisherSolution/Views/Home/Subscriptions.cshtml
+++ b/src/SaaS.SDK.PublisherSolution/Views/Home/Subscriptions.cshtml
@@ -78,7 +78,7 @@
                                                         {
                                                             <a class="dropdown-item cm-dropdown-option" asp-action="RecordUsage" asp-controller="Home" asp-route-subscriptionId="@subscription.SubscribeId">Manage Usage</a>
                                                         }
-                                                        @if (subscription.SubscriptionStatus == SubscriptionStatusEnumExtension.PendingActivation || subscription.SubscriptionStatus == SubscriptionStatusEnumExtension.PendingFulfillmentStart)
+                                                        @if (subscription.SubscriptionStatus == SubscriptionStatusEnumExtension.PendingActivation || subscription.SubscriptionStatus == SubscriptionStatusEnumExtension.PendingFulfillmentStart || subscription.SubscriptionStatus == SubscriptionStatusEnumExtension.ActivationFailed)
                                                         {
                                                             <a class="dropdown-item cm-dropdown-option" asp-action="SubscriptionDetails" asp-route-subscriptionId="@Model.Subscriptions[i].Id" asp-route-planId="@Model.Subscriptions[i].PlanId" asp-route-operation="Activate">Activate</a>
                                                         }


### PR DESCRIPTION
This "Activate" feature fixes issue #254 and allows for subscriptions that have the status "Activation Failed" to be able to activate their subscriptions