### PR TITLE
added performance fixes for subscriptions

### DIFF
--- a/src/SaaS.SDK.CustomerProvisioning/Controllers/HomeController.cs
+++ b/src/SaaS.SDK.CustomerProvisioning/Controllers/HomeController.cs
@@ -300,9 +300,11 @@ namespace Microsoft.Marketplace.SaasKit.Client.Controllers
                     this.TempData["ShowWelcomeScreen"] = "True";
                     SubscriptionViewModel subscriptionDetail = new SubscriptionViewModel();
                     subscriptionDetail.Subscriptions = this.subscriptionService.GetPartnerSubscription(this.CurrentUserEmailAddress, default, true).ToList();
+                    var allPlans = this.planRepository.Get().ToList();
                     foreach (var subscription in subscriptionDetail.Subscriptions)
                     {
-                        Plans planDetail = this.planRepository.GetById(subscription.PlanId);
+                        Plans planDetail = allPlans.Where(plan => plan.PlanId == subscription.PlanId).FirstOrDefault(); // Can return different plans with same ID
+                        // Plans planDetail = allPlans.Where(plan => plan.PlanGuid == subscription.PlanGuid).FirstOrDefault(); Requires PR#270
                         subscription.IsAutomaticProvisioningSupported = Convert.ToBoolean(this.applicationConfigRepository.GetValueByName("IsAutomaticProvisioningSupported"));
                         subscription.IsPerUserPlan = planDetail.IsPerUser.HasValue ? planDetail.IsPerUser.Value : false;
                     }

--- a/src/SaaS.SDK.CustomerProvisioning/Controllers/HomeController.cs
+++ b/src/SaaS.SDK.CustomerProvisioning/Controllers/HomeController.cs
@@ -317,7 +317,7 @@ namespace Microsoft.Marketplace.SaasKit.Client.Controllers
                         subscriptionDetail.ErrorMessage = Convert.ToString(this.TempData["ErrorMsg"]);
                     }
 
-                  return this.View(subscriptionDetail);
+                    return this.View(subscriptionDetail);
                 }
                 else
                 {

--- a/src/SaaS.SDK.CustomerProvisioning/Controllers/HomeController.cs
+++ b/src/SaaS.SDK.CustomerProvisioning/Controllers/HomeController.cs
@@ -304,7 +304,7 @@ namespace Microsoft.Marketplace.SaasKit.Client.Controllers
                     foreach (var subscription in subscriptionDetail.Subscriptions)
                     {
                         Plans planDetail = allPlans.Where(plan => plan.PlanId == subscription.PlanId).FirstOrDefault(); // Can return different plans with same ID
-                        // Plans planDetail = allPlans.Where(plan => plan.PlanGuid == subscription.PlanGuid).FirstOrDefault(); Requires PR#270
+                        // Plans planDetail = allPlans.Where(plan => plan.PlanGuid == subscription.PlanGuid).FirstOrDefault(); // Requires PR#270
                         subscription.IsAutomaticProvisioningSupported = Convert.ToBoolean(this.applicationConfigRepository.GetValueByName("IsAutomaticProvisioningSupported"));
                         subscription.IsPerUserPlan = planDetail.IsPerUser.HasValue ? planDetail.IsPerUser.Value : false;
                     }
@@ -317,7 +317,7 @@ namespace Microsoft.Marketplace.SaasKit.Client.Controllers
                         subscriptionDetail.ErrorMessage = Convert.ToString(this.TempData["ErrorMsg"]);
                     }
 
-                    return this.View(subscriptionDetail);
+                  return this.View(subscriptionDetail);
                 }
                 else
                 {

--- a/src/SaaS.SDK.PublisherSolution/Controllers/HomeController.cs
+++ b/src/SaaS.SDK.PublisherSolution/Controllers/HomeController.cs
@@ -236,8 +236,9 @@ namespace Microsoft.Marketplace.Saas.Web.Controllers
                     var allPlans = this.planRepository.Get().ToList();
                     foreach (var subscription in allSubscriptionDetails)
                     {
-                        SubscriptionResultExtension subscriptionDetailExtension = this.subscriptionService.PrepareSubscriptionResponse(subscription);
-                        Plans planDetail = this.planRepository.GetById(subscriptionDetailExtension.PlanId);
+                        SubscriptionResultExtension subscriptionDetailExtension = this.subscriptionService.PrepareSubscriptionResponse(subscription, allPlans);
+                        Plans planDetail = allPlans.Where(s => s.PlanId == subscription.AmpplanId).FirstOrDefault(); // Will return plans with duplicate Plan IDs
+                        //Plans planDetail = allPlans.Where(s => s.PlanGuid == subscription.PlanGuid).FirstOrDefault(); // Uses Guid value from PR#270
                         subscriptionDetailExtension.IsPerUserPlan = planDetail.IsPerUser.HasValue ? planDetail.IsPerUser.Value : false;
                         if (subscriptionDetailExtension != null && subscriptionDetailExtension.SubscribeId > 0)
                         {


### PR DESCRIPTION
This solution reduces the admin subscriptions load time by ~75% and the customer subscription load time by ~45%.

Benchmarks on local device (averages):
- Admin page load time went from 2:05 to around 30 seconds.
- Customer page went from 1:15 to around 40 seconds.