### PR TITLE
Added webhook renew event

### DIFF
--- a/src/SaaS.SDK.CustomerProvisioning/WebHook/WebhookHandler.cs
+++ b/src/SaaS.SDK.CustomerProvisioning/WebHook/WebhookHandler.cs
@@ -282,7 +282,12 @@ namespace Microsoft.Marketplace.SaaS.SDK.Services.WebHook
             await Task.CompletedTask;
         }
 
-        public async Task RenewededAsync(WebhookPayload payload)
+        /// <summary>
+        /// Renewed the subscription.
+        /// </summary>
+        /// <param name="payload">The payload.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        public async Task RenewededAsync()
         {
             await this.applicationLogService.AddApplicationLog("Offer Successfully Renewed.").ConfigureAwait(false);
 

--- a/src/SaaS.SDK.CustomerProvisioning/WebHook/WebhookHandler.cs
+++ b/src/SaaS.SDK.CustomerProvisioning/WebHook/WebhookHandler.cs
@@ -287,7 +287,7 @@ namespace Microsoft.Marketplace.SaaS.SDK.Services.WebHook
         /// </summary>
         /// <param name="payload">The payload.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task RenewededAsync()
+        public async Task RenewedAsync()
         {
             await this.applicationLogService.AddApplicationLog("Offer Successfully Renewed.").ConfigureAwait(false);
 

--- a/src/SaaS.SDK.CustomerProvisioning/WebHook/WebhookHandler.cs
+++ b/src/SaaS.SDK.CustomerProvisioning/WebHook/WebhookHandler.cs
@@ -282,6 +282,13 @@ namespace Microsoft.Marketplace.SaaS.SDK.Services.WebHook
             await Task.CompletedTask;
         }
 
+        public async Task RenewededAsync(WebhookPayload payload)
+        {
+            await this.applicationLogService.AddApplicationLog("Offer Successfully Renewed.").ConfigureAwait(false);
+
+            await Task.CompletedTask;
+        }
+
         /// <summary>
         /// Suspended the asynchronous.
         /// </summary>
@@ -348,7 +355,7 @@ namespace Microsoft.Marketplace.SaaS.SDK.Services.WebHook
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public async Task UnknownActionAsync(WebhookPayload payload)
         {
-            await this.applicationLogService.AddApplicationLog("Offer Received an unknow action: " + payload.Action).ConfigureAwait(false);
+            await this.applicationLogService.AddApplicationLog("Offer Received an unknown action: " + payload.Action).ConfigureAwait(false);
 
             await Task.CompletedTask;
         }

--- a/src/SaaS.SDK.Services/WebHook/IWebhookHandler.cs
+++ b/src/SaaS.SDK.Services/WebHook/IWebhookHandler.cs
@@ -49,6 +49,8 @@ namespace Microsoft.Marketplace.SaaS.SDK.Services.WebHook
         /// </summary>
         /// <param name="payload">The payload.</param>
         /// <returns>Unsubscribed Async</returns>
-        Task UnknownActionAsync(WebhookPayload payload);        
+        Task UnknownActionAsync(WebhookPayload payload);
+
+        Task RenewededAsync(WebhookPayload payload);
     }
 }

--- a/src/SaaS.SDK.Services/WebHook/IWebhookHandler.cs
+++ b/src/SaaS.SDK.Services/WebHook/IWebhookHandler.cs
@@ -51,6 +51,11 @@ namespace Microsoft.Marketplace.SaaS.SDK.Services.WebHook
         /// <returns>Unsubscribed Async</returns>
         Task UnknownActionAsync(WebhookPayload payload);
 
-        Task RenewededAsync();
+        /// <summary>
+        /// Renewed subscription state
+        /// </summary>
+        /// <param name="payload">The payload.</param>
+        /// <returns>Renewed Async</returns>
+        Task RenewedAsync();
     }
 }

--- a/src/SaaS.SDK.Services/WebHook/IWebhookHandler.cs
+++ b/src/SaaS.SDK.Services/WebHook/IWebhookHandler.cs
@@ -51,6 +51,6 @@ namespace Microsoft.Marketplace.SaaS.SDK.Services.WebHook
         /// <returns>Unsubscribed Async</returns>
         Task UnknownActionAsync(WebhookPayload payload);
 
-        Task RenewededAsync(WebhookPayload payload);
+        Task RenewededAsync();
     }
 }

--- a/src/SaaS.SDK.Services/WebHook/WebhookAction.cs
+++ b/src/SaaS.SDK.Services/WebHook/WebhookAction.cs
@@ -46,6 +46,13 @@ namespace Microsoft.Marketplace.SaaS.SDK.Services.WebHook
         [EnumMember(Value = "Reinstate")]
         Reinstate,
 
+        /// (When resource has been reinstated after suspension)
+        /// <summary>
+        /// The reinstate
+        /// </summary>
+        [EnumMember(Value = "Renew")]
+        Renew,
+        
         /// <summary>
         /// The transfer
         /// </summary>

--- a/src/SaaS.SDK.Services/WebHook/WebhookProcessor.cs
+++ b/src/SaaS.SDK.Services/WebHook/WebhookProcessor.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Marketplace.SaaS.SDK.Services.WebHook
                     break;
 
                 case WebhookAction.Renew:
-                    await this.webhookHandler.RenewededAsync().ConfigureAwait(false);
+                    await this.webhookHandler.RenewedAsync().ConfigureAwait(false);
                     break;
                 
                 default:

--- a/src/SaaS.SDK.Services/WebHook/WebhookProcessor.cs
+++ b/src/SaaS.SDK.Services/WebHook/WebhookProcessor.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Marketplace.SaaS.SDK.Services.WebHook
                     break;
 
                 case WebhookAction.Renew:
-                    await this.webhookHandler.RenewededAsync(payload).ConfigureAwait(false);
+                    await this.webhookHandler.RenewededAsync().ConfigureAwait(false);
                     break;
                 
                 default:

--- a/src/SaaS.SDK.Services/WebHook/WebhookProcessor.cs
+++ b/src/SaaS.SDK.Services/WebHook/WebhookProcessor.cs
@@ -61,6 +61,10 @@ namespace Microsoft.Marketplace.SaaS.SDK.Services.WebHook
                     await this.webhookHandler.ReinstatedAsync(payload).ConfigureAwait(false);
                     break;
 
+                case WebhookAction.Renew:
+                    await this.webhookHandler.RenewededAsync(payload).ConfigureAwait(false);
+                    break;
+                
                 default:
                     await this.webhookHandler.UnknownActionAsync(payload).ConfigureAwait(false);
                     break;


### PR DESCRIPTION
When a Renewed event is received on the webhook, a message is written to the event log. The event is no longer throwing an error or being swallowed.