### PR TITLE
Should not override the SignOut BaseController method.

### DIFF
--- a/src/AdminSite/Controllers/AccountController.cs
+++ b/src/AdminSite/Controllers/AccountController.cs
@@ -29,7 +29,7 @@
         /// <returns>
         /// The <see cref="IActionResult" />.
         /// </returns>
-        public override SignOutResult SignOut()
+        public new SignOutResult SignOut()
         {
             return this.SignOut(
                 new AuthenticationProperties

--- a/src/CustomerSite/Controllers/AccountController.cs
+++ b/src/CustomerSite/Controllers/AccountController.cs
@@ -29,7 +29,7 @@
         /// <returns>
         /// The <see cref="IActionResult" />.
         /// </returns>
-        public override SignOutResult SignOut()
+        public new SignOutResult SignOut()
         {
             return this.SignOut(
                 new AuthenticationProperties


### PR DESCRIPTION
The SignOut method in the BaseController is a NonAction Helper method. Our controller's SignOut needs to be "new" as it's an action we want to call (arguably, should not have called it SignOut)

fixed #396 