### PR TITLE
Refresh Plan Name

### DIFF
--- a/src/AdminSite/Controllers/HomeController.cs
+++ b/src/AdminSite/Controllers/HomeController.cs
@@ -696,7 +696,6 @@ namespace Microsoft.Marketplace.Saas.Web.Controllers
                     {
                         //initiate change plan
                         var currentUserId = this.userService.GetUserIdFromEmailAddress(this.CurrentUserEmailAddress);
-                        var currentSubscription = this.subscriptionService.GetSubscriptionsBySubscriptionId(subscriptionDetail.Id);
                         var jsonResult = await this.fulfillApiService.ChangePlanForSubscriptionAsync(subscriptionDetail.Id, subscriptionDetail.PlanId).ConfigureAwait(false);
                         var changePlanOperationStatus = OperationStatusEnum.InProgress;
 
@@ -727,16 +726,6 @@ namespace Microsoft.Marketplace.Saas.Web.Controllers
                             {
                                 this.logger.LogInformation($"Plan Change Success. SubscriptionId: {subscriptionDetail.Id} ToPlan : {subscriptionDetail.PlanId} UserId: {currentUserId} OperationId: {jsonResult.OperationId}.");
                                 await this.applicationLogService.AddApplicationLog($"Plan Change Success. SubscriptionId: {subscriptionDetail.Id} ToPlan: {subscriptionDetail.PlanId} UserId: {currentUserId} OperationId: {jsonResult.OperationId}.").ConfigureAwait(false);
-                                this.subscriptionService.UpdateSubscriptionPlan(subscriptionDetail.Id, subscriptionDetail.PlanId);
-                                this.subscriptionLogRepository.Save(new SubscriptionAuditLogs
-                                {
-                                    Attribute = Convert.ToString(SubscriptionLogAttributes.Plan),
-                                    SubscriptionId = subscriptionDetail.SubscribeId,
-                                    CreateBy = currentUserId,
-                                    CreateDate = DateTime.Now,
-                                    OldValue = currentSubscription.PlanId,
-                                    NewValue = subscriptionDetail.PlanId
-                                });
                             }
                             else
                             {

--- a/src/AdminSite/Controllers/HomeController.cs
+++ b/src/AdminSite/Controllers/HomeController.cs
@@ -934,7 +934,10 @@ namespace Microsoft.Marketplace.Saas.Web.Controllers
             }
             catch (Exception ex)
             {
-                this.logger.LogError("Message:{0} :: {1}   ", ex.Message, ex.InnerException);
+                var errorMessage = $"Message: {ex.Message} ({ex.InnerException})";
+                logger.LogError(errorMessage);
+                applicationLogService.AddApplicationLog(errorMessage).GetAwaiter().GetResult();
+                
                 return BadRequest();
             }
 

--- a/src/AdminSite/Controllers/HomeController.cs
+++ b/src/AdminSite/Controllers/HomeController.cs
@@ -550,8 +550,8 @@ namespace Microsoft.Marketplace.Saas.Web.Controllers
             {
                 if (this.User.Identity.IsAuthenticated)
                 {
-                    var subscriptionDetail = this.subscriptionService.GetPartnerSubscription(this.CurrentUserEmailAddress, subscriptionId).FirstOrDefault();
-                    return this.PartialView(subscriptionDetail);
+                    var subscriptionDetail = this.subscriptionService.GetSubscriptionsBySubscriptionId(subscriptionId);
+                    return this.View(subscriptionDetail);
                 }
                 else
                 {

--- a/src/AdminSite/Controllers/HomeController.cs
+++ b/src/AdminSite/Controllers/HomeController.cs
@@ -696,6 +696,7 @@ namespace Microsoft.Marketplace.Saas.Web.Controllers
                     {
                         //initiate change plan
                         var currentUserId = this.userService.GetUserIdFromEmailAddress(this.CurrentUserEmailAddress);
+                        var currentSubscription = this.subscriptionService.GetSubscriptionsBySubscriptionId(subscriptionDetail.Id);
                         var jsonResult = await this.fulfillApiService.ChangePlanForSubscriptionAsync(subscriptionDetail.Id, subscriptionDetail.PlanId).ConfigureAwait(false);
                         var changePlanOperationStatus = OperationStatusEnum.InProgress;
 
@@ -726,6 +727,16 @@ namespace Microsoft.Marketplace.Saas.Web.Controllers
                             {
                                 this.logger.LogInformation($"Plan Change Success. SubscriptionId: {subscriptionDetail.Id} ToPlan : {subscriptionDetail.PlanId} UserId: {currentUserId} OperationId: {jsonResult.OperationId}.");
                                 await this.applicationLogService.AddApplicationLog($"Plan Change Success. SubscriptionId: {subscriptionDetail.Id} ToPlan: {subscriptionDetail.PlanId} UserId: {currentUserId} OperationId: {jsonResult.OperationId}.").ConfigureAwait(false);
+                                this.subscriptionService.UpdateSubscriptionPlan(subscriptionDetail.Id, subscriptionDetail.PlanId);
+                                this.subscriptionLogRepository.Save(new SubscriptionAuditLogs
+                                {
+                                    Attribute = Convert.ToString(SubscriptionLogAttributes.Plan),
+                                    SubscriptionId = subscriptionDetail.SubscribeId,
+                                    CreateBy = currentUserId,
+                                    CreateDate = DateTime.Now,
+                                    OldValue = currentSubscription.PlanId,
+                                    NewValue = subscriptionDetail.PlanId
+                                });
                             }
                             else
                             {
@@ -844,8 +855,11 @@ namespace Microsoft.Marketplace.Saas.Web.Controllers
                 var subscriptions = this.fulfillApiService.GetAllSubscriptionAsync().GetAwaiter().GetResult();
                 foreach (SubscriptionResult subscription in subscriptions)
                 {
+                    var customerUserId = 0;
+                    var currentSubscription = this.subscriptionService.GetSubscriptionsBySubscriptionId(subscription.Id);
+                    
                     // Step 2: Check if they Exist in DB - Create if dont exist
-                    if (this.subscriptionRepo.GetById(subscription.Id) == null)
+                    if (currentSubscription == null)
                     {
                         // Step 3: Add/Update the Offer
                         Guid OfferId = this.offersRepository.Add(new Offers()
@@ -858,7 +872,7 @@ namespace Microsoft.Marketplace.Saas.Web.Controllers
                         });
 
                         // Step 4: Add/Update the Plans. For Unsubscribed Only Add current plan from subscription information
-                        if(subscription.SaasSubscriptionStatus == SubscriptionStatusEnum.Unsubscribed)
+                        if (subscription.SaasSubscriptionStatus == SubscriptionStatusEnum.Unsubscribed)
                         {
                             PlanDetailResultExtension planDetails = new PlanDetailResultExtension
                             {
@@ -883,26 +897,50 @@ namespace Microsoft.Marketplace.Saas.Web.Controllers
                         }
 
                         // Step 5: Add/Update the current user from Subscription information
-                        var customerUserId = this.userService.AddUser(new PartnerDetailViewModel { FullName = subscription.Beneficiary.EmailId, EmailAddress = subscription.Beneficiary.EmailId });
-
-                        // Step 6: Add Subscription
-                        var subscribeId = this.subscriptionService.AddOrUpdatePartnerSubscriptions(subscription, customerUserId);
-
-                        // Step 7: Add Subscription Audit
-                        if (subscribeId > 0 && subscription.SaasSubscriptionStatus == SubscriptionStatusEnum.PendingFulfillmentStart)
-                        {
-                            SubscriptionAuditLogs auditLog = new SubscriptionAuditLogs()
-                            {
-                                Attribute = Convert.ToString(SubscriptionLogAttributes.Status),
-                                SubscriptionId = subscribeId,
-                                NewValue = SubscriptionStatusEnum.PendingFulfillmentStart.ToString(),
-                                OldValue = "None",
-                                CreateBy = currentUserId,
-                                CreateDate = DateTime.Now,
-                            };
-                            this.subscriptionLogRepository.Save(auditLog);
-                        }
+                        customerUserId = this.userService.AddUser(new PartnerDetailViewModel { FullName = subscription.Beneficiary.EmailId, EmailAddress = subscription.Beneficiary.EmailId });
                     }
+
+                    // Step 6: Add Subscription
+                    var subscriptionId = this.subscriptionService.AddOrUpdatePartnerSubscriptions(subscription, customerUserId);
+
+                    // Step 7: Add Subscription Audit
+                    if (currentSubscription != null && subscription.SaasSubscriptionStatus.ToString() != currentSubscription.SubscriptionStatus.ToString())
+                    {
+                        this.subscriptionLogRepository.Save(new SubscriptionAuditLogs()
+                        {
+                            Attribute = $"{Convert.ToString(SubscriptionLogAttributes.Status)}-Refresh",
+                            SubscriptionId = subscriptionId,
+                            NewValue = subscription.SaasSubscriptionStatus.ToString(),
+                            OldValue = currentSubscription.SubscriptionStatus.ToString(),
+                            CreateBy = currentUserId,
+                            CreateDate = DateTime.Now
+                        });
+                    }
+                    if (currentSubscription != null && subscription.PlanId != currentSubscription.PlanId)
+                    {
+                        this.subscriptionLogRepository.Save(new SubscriptionAuditLogs()
+                        {
+                            Attribute =$"{Convert.ToString(SubscriptionLogAttributes.Plan)}-Refresh",
+                            SubscriptionId = subscriptionId,
+                            NewValue = subscription.PlanId.ToString(),
+                            OldValue = currentSubscription.PlanId,
+                            CreateBy = currentUserId,
+                            CreateDate = DateTime.Now
+                        });
+                    }
+                    if (currentSubscription != null && subscription.Quantity != currentSubscription.Quantity)
+                    {
+                        this.subscriptionLogRepository.Save(new SubscriptionAuditLogs()
+                        {
+                            Attribute = $"{Convert.ToString(SubscriptionLogAttributes.Quantity)}-Refresh",
+                            SubscriptionId = subscriptionId,
+                            NewValue = subscription.Quantity.ToString(),
+                            OldValue = currentSubscription.Quantity.ToString(),
+                            CreateBy = currentUserId,
+                            CreateDate = DateTime.Now
+                        });
+                    }
+
                 }
             }
             catch (Exception ex)

--- a/src/AdminSite/Controllers/HomeController.cs
+++ b/src/AdminSite/Controllers/HomeController.cs
@@ -643,7 +643,7 @@ namespace Microsoft.Marketplace.Saas.Web.Controllers
                     var subscriptionDetail = this.subscriptionService.GetSubscriptionsBySubscriptionId(subscriptionId);
                     subscriptionDetail.PlanList = this.subscriptionService.GetAllSubscriptionPlans();
 
-                    return this.PartialView(subscriptionDetail);
+                    return this.View(subscriptionDetail);
                 }
                 else
                 {

--- a/src/AdminSite/Controllers/HomeController.cs
+++ b/src/AdminSite/Controllers/HomeController.cs
@@ -848,7 +848,7 @@ namespace Microsoft.Marketplace.Saas.Web.Controllers
                     var currentSubscription = this.subscriptionService.GetSubscriptionsBySubscriptionId(subscription.Id);
                     
                     // Step 2: Check if they Exist in DB - Create if dont exist
-                    if (currentSubscription == null)
+                    if (currentSubscription.Name == null)
                     {
                         // Step 3: Add/Update the Offer
                         Guid OfferId = this.offersRepository.Add(new Offers()

--- a/src/AdminSite/Program.cs
+++ b/src/AdminSite/Program.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Marketplace.Saas.Web
         })
         .ConfigureWebHostDefaults(webBuilder =>
         {
-            webBuilder.UseUrls("https://*:5081", "http://*:5080");
+            //webBuilder.UseUrls("https://*:5081", "http://*:5080");
             webBuilder.UseStartup<Startup>();
         });
     }

--- a/src/AdminSite/Views/Home/SubscriptionDetails.cshtml
+++ b/src/AdminSite/Views/Home/SubscriptionDetails.cshtml
@@ -48,7 +48,7 @@
                             @Html.DisplayName("Status ")
                         </dt>
                         <dd class="col-sm-9 p-2 p10">
-                            @Html.DisplayFor(model => model.SaasSubscriptionStatus)
+                            @Html.DisplayFor(model => model.SubscriptionStatus)
                         </dd>
                         <dt class="col-sm-3 p-2 p10">
                             @Html.DisplayName("Purchaser Email ")

--- a/src/AdminSite/Views/Home/SubscriptionQuantityDetail.cshtml
+++ b/src/AdminSite/Views/Home/SubscriptionQuantityDetail.cshtml
@@ -50,7 +50,10 @@
                         </dd>
                     </dl>
                     <div class="text-right">
-                        <button type="button" onclick="confirmQuantityDialog()" class="cm-button-default mt40 mr20 text-right">Change Quantity</button>
+                        <div id="frmSpinner" class="spinner-border mt-2" role="status" style="margin-bottom: -10px; margin-right: 20px;" hidden>
+                            <span class="sr-only">Processing...</span>
+                        </div>
+                        <button id="frmButton" type="button" onclick="confirmQuantityDialog()" class="btn cm-button-default mt40 mr20 text-right">Change Quantity</button>
                     </div>
                 </div>
             </form>

--- a/src/AdminSite/Views/Home/Subscriptions.cshtml
+++ b/src/AdminSite/Views/Home/Subscriptions.cshtml
@@ -171,7 +171,9 @@
             dangerMode: true,
         })
             .then((willChange) => {
-                if (willChange) {
+                if (willChange) {           
+                    $("#frmButton").prop("disabled", true);
+                    $("#frmSpinner").prop("hidden", false);
                     $("#frmSubscriptionDetail").submit();
                 }
             });

--- a/src/AdminSite/Views/Home/Subscriptions.cshtml
+++ b/src/AdminSite/Views/Home/Subscriptions.cshtml
@@ -135,7 +135,11 @@
                 $('#myModal').modal();
             },
             error: function () {
-                alert("Content load failed.");
+                swal({
+                    title: "Error",
+                    text: "Content load failed.",
+                    icon: "Error"
+                })
             }
         });
     }
@@ -151,18 +155,16 @@
                 $('#myModal').modal();
             },
             error: function () {
-                alert("Content load failed.");
+                swal({
+                    title: "Error",
+                    text: "Content load failed.",
+                    icon: "Error"
+                })
             }
         });
     }
 
     function confirmDialog() {
-        //var isConfirm = confirm('Are you sure you want to change the plan?');
-        //debugger
-        //if (isConfirm) {
-        //    $("#frmSubscriptionDetail").submit();
-        //}
-
         var newPlanName = $('#PlanId').val();
         swal({
             text: "Are you sure you want to switch to " + newPlanName + " plan?",
@@ -188,7 +190,6 @@
             success: function (data) {
                 $('#myModal').html(data);
                 $('#myModal').modal();
-
             },
             error: function () {
                 swal({
@@ -200,15 +201,9 @@
         });
     }
     function confirmQuantityDialog() {
-        //var isConfirm = confirm('Are you sure you want to change the plan?');
-        //debugger
-        //if (isConfirm) {
-        //    $("#frmSubscriptionDetail").submit();
-        //}
-
-        var newPlanName = $('#PlanId').val();
+        var newQuantity = $('#Quantity').val();
         swal({
-            text: "Are you sure you want to Change the quantity?",
+            text: "Are you sure you want to Change the quantity to " + newQuantity + "?",
             icon: "warning",
             buttons: true,
             dangerMode: true,
@@ -216,6 +211,8 @@
             .then((willChange) => {
                 debugger;
                 if (willChange) {
+                    $("#frmButton").prop("disabled", true);
+                    $("#frmSpinner").prop("hidden", false);
                     $("#frmSubscriptionQuantityDetailAdmin").submit();
                 }
             });

--- a/src/AdminSite/Views/Home/ViewSubscriptionDetail.cshtml
+++ b/src/AdminSite/Views/Home/ViewSubscriptionDetail.cshtml
@@ -45,7 +45,10 @@
                         </dd>
                     </dl>
                     <div class="text-right">
-                        <button type="button" onclick="confirmDialog()" class="cm-button-default mt40 mr20 text-right">Change Plan</button>
+                        <div id="frmSpinner" class="spinner-border mt-2" role="status" style="margin-bottom: -10px; margin-right: 20px;" hidden>
+                            <span class="sr-only">Processing...</span>
+                        </div>
+                        <button id="frmButton" type="button" onclick="confirmDialog()" class="btn cm-button-default text-right">Change Plan</button>
                     </div>
                 </div>
             </form>

--- a/src/CustomerSite/Controllers/HomeController.cs
+++ b/src/CustomerSite/Controllers/HomeController.cs
@@ -639,7 +639,6 @@ namespace Microsoft.Marketplace.SaasKit.Client.Controllers
                         {
                             //initiate change plan
                             var currentUserId = this.userService.GetUserIdFromEmailAddress(this.CurrentUserEmailAddress);
-                            var currentSubscription = this.subscriptionService.GetSubscriptionsBySubscriptionId(subscriptionDetail.Id);
                             var jsonResult = await this.apiService.ChangePlanForSubscriptionAsync(subscriptionDetail.Id, subscriptionDetail.PlanId).ConfigureAwait(false);
                             var changePlanOperationStatus = OperationStatusEnum.InProgress;
 
@@ -670,16 +669,6 @@ namespace Microsoft.Marketplace.SaasKit.Client.Controllers
                                 {
                                     this.logger.LogInformation($"Plan Change Success. SubscriptionId: {subscriptionDetail.Id} ToPlan : {subscriptionDetail.PlanId} UserId: {currentUserId} OperationId: {jsonResult.OperationId}.");
                                     await this.applicationLogService.AddApplicationLog($"Plan Change Success. SubscriptionId: {subscriptionDetail.Id} ToPlan: {subscriptionDetail.PlanId} UserId: {currentUserId} OperationId: {jsonResult.OperationId}.").ConfigureAwait(false);
-                                    this.subscriptionService.UpdateSubscriptionPlan(subscriptionDetail.Id, subscriptionDetail.PlanId);
-                                    this.subscriptionLogRepository.Save(new SubscriptionAuditLogs
-                                    {
-                                        Attribute = Convert.ToString(SubscriptionLogAttributes.Plan),
-                                        SubscriptionId = subscriptionDetail.SubscribeId,
-                                        CreateBy = currentUserId,
-                                        CreateDate = DateTime.Now,
-                                        OldValue = currentSubscription.PlanId,
-                                        NewValue = subscriptionDetail.PlanId
-                                    });
                                 }
                                 else
                                 {

--- a/src/CustomerSite/Views/Home/SubscriptionDetail.cshtml
+++ b/src/CustomerSite/Views/Home/SubscriptionDetail.cshtml
@@ -57,7 +57,10 @@
                             <button type="button" onclick="confirmDialog()" class="btn btn-success text-right">Change Plan</button>
                         </div>*@
                     <div class="text-right">
-                        <button type="button" onclick="confirmDialog()" class="cm-button-default mt40 mr20 text-right">Change Plan</button>
+                        <div id="frmSpinner" class="spinner-border mt-2" role="status" style="margin-bottom: -10px; margin-right: 20px;" hidden>
+                            <span class="sr-only">Processing...</span>
+                        </div>
+                        <button id="frmButton" type="button" onclick="confirmDialog()" class="btn cm-button-default text-right">Change Plan</button>
                     </div>
                 </div>
             </form>

--- a/src/CustomerSite/Views/Home/SubscriptionQuantityDetail.cshtml
+++ b/src/CustomerSite/Views/Home/SubscriptionQuantityDetail.cshtml
@@ -50,7 +50,10 @@
                         </dd>
                     </dl>
                     <div class="text-right">
-                        <button type="button" onclick="confirmQuantityDialog()" class="cm-button-default mt40 mr20 text-right">Change Quantity</button>
+                        <div id="frmSpinner" class="spinner-border mt-2" role="status" style="margin-bottom: -10px; margin-right: 20px;" hidden>
+                            <span class="sr-only">Processing...</span>
+                        </div>
+                        <button id="frmButton" type="button" onclick="confirmQuantityDialog()" class="btn cm-button-default mt40 mr20 text-right">Change Quantity</button>
                     </div>
                 </div>
             </form>

--- a/src/CustomerSite/Views/Home/Subscriptions.cshtml
+++ b/src/CustomerSite/Views/Home/Subscriptions.cshtml
@@ -128,7 +128,11 @@
                 $('#myModal').modal();
             },
             error: function () {
-                alert("Content load failed.");
+                swal({
+                    title: "Error",
+                    text: "Content load failed.",
+                    icon: "Error"
+                })
             }
         });
     }
@@ -145,7 +149,11 @@
 
             },
             error: function () {
-                alert("Content load failed.");
+                swal({
+                    title: "Error",
+                    text: "Content load failed.",
+                    icon: "Error"
+                })
             }
         });
     }
@@ -161,18 +169,16 @@
                 $('#myModal').modal();
             },
             error: function () {
-                alert("Content load failed.");
+                swal({
+                    title: "Error",
+                    text: "Content load failed.",
+                    icon: "Error"
+                })
             }
         });
     }
 
     function confirmDialog() {
-        //var isConfirm = confirm('Are you sure you want to change the plan?');
-        //debugger
-        //if (isConfirm) {
-        //    $("#frmSubscriptionDetail").submit();
-        //}
-
         var newPlanName = $('#PlanId').val();
         swal({
             text: "Are you sure you want to switch to " + newPlanName + " plan?",
@@ -191,15 +197,9 @@
     }
 
     function confirmQuantityDialog() {
-        //var isConfirm = confirm('Are you sure you want to change the plan?');
-        //debugger
-        //if (isConfirm) {
-        //    $("#frmSubscriptionDetail").submit();
-        //}
-
-        var newPlanName = $('#PlanId').val();
+        var newQuantity = $('#Quantity').val();
         swal({
-            text: "Are you sure you want to Change the quantity?",
+            text: "Are you sure you want to Change the quantity to " + newQuantity + "?",
             icon: "warning",
             buttons: true,
             dangerMode: true,
@@ -207,6 +207,8 @@
             .then((willChange) => {
                 debugger;
                 if (willChange) {
+                    $("#frmButton").prop("disabled", true);
+                    $("#frmSpinner").prop("hidden", false);
                     $("#frmSubscriptionQuantityDetail").submit();
                 }
             });

--- a/src/CustomerSite/Views/Home/Subscriptions.cshtml
+++ b/src/CustomerSite/Views/Home/Subscriptions.cshtml
@@ -61,7 +61,7 @@
                                                         @if (subscription.SubscriptionStatus == SubscriptionStatusEnumExtension.Subscribed)
                                                         {
                                                             <a class="dropdown-item cm-dropdown-option" asp-action="ViewSubscription" asp-route-subscriptionId="@Model.Subscriptions[i].Id" asp-route-planId="@Model.Subscriptions[i].PlanId" asp-route-operation="Deactivate">Unsubscribe</a>
-                                                            @if (subscription.IsAutomaticProvisioningSupported == true)
+                                                            @if (subscription.AcceptSubscriptionUpdates == true)
                                                             {
                                                                 <a class="dropdown-item cm-dropdown-option" onclick="ViewSubscriptionDetail('@Model.Subscriptions[i].Id')" data-target="#Mymode">Change Plan</a>      
                                                                 @if (subscription.IsPerUserPlan)
@@ -183,6 +183,8 @@
             .then((willChange) => {
                 debugger;
                 if (willChange) {
+                    $("#frmButton").prop("disabled", true);
+                    $("#frmSpinner").prop("hidden", false);
                     $("#frmSubscriptionDetail").submit();
                 }
             });

--- a/src/Services/Models/SubscriptionResultExtension.cs
+++ b/src/Services/Models/SubscriptionResultExtension.cs
@@ -66,5 +66,11 @@ namespace Microsoft.Marketplace.SaaS.SDK.Services.Models
         ///   <c>true</c> if this instance is automatic provisioning supported; otherwise, <c>false</c>.
         /// </value>
         public bool IsAutomaticProvisioningSupported { get; set; }
+       
+        
+        /// <summary>
+        /// Gets or sets a value indicating if we allow subscription updates on the customer side.
+        /// </summary>
+        public bool AcceptSubscriptionUpdates { get; set; }
     }
 }


### PR DESCRIPTION
### Logic:

- when changing plan, ensure we update the database with the new plan for the offer (and log)
- when fetching subscription list, ensure we refresh plan name, quantity or status and log

### UI:
- change plan / change quantity are long running operations (30s-60s). Disable button and show spinner on page while operation is in progress for both change plan and change quantity modals both in admin portal and customer portal
 
![image](https://user-images.githubusercontent.com/8275679/200210791-8a740139-55bb-4b56-8edc-e75bd6f64523.png)

Addresses #345, #350, #219
Also fixes #353 , #354 

