### PR TITLE
fix KV reference on CloudShell

### DIFF
--- a/deployment/Deploy.ps1
+++ b/deployment/Deploy.ps1
@@ -264,11 +264,9 @@ $WebAppNameAdmin=$WebAppNamePrefix+"-admin"
 $WebAppNamePortal=$WebAppNamePrefix+"-portal"
 $KeyVault=$WebAppNamePrefix+"-kv"
 $KeyVault=$KeyVault -replace '_',''
-$ADApplicationSecretKeyVault='"@Microsoft.KeyVault(VaultName=' + $KeyVault+ ';SecretName=ADApplicationSecret)"'
-if ($PsVersionTable.Platform -ne 'Unix') {
-	$ADApplicationSecretKeyVault='@Microsoft.KeyVault(VaultName=' + $KeyVault+ ';SecretName=ADApplicationSecret)'
-}
-$DefaultConnectionKeyVault='"@Microsoft.KeyVault(VaultName=' + $KeyVault+ ';SecretName=DefaultConnection)"'
+#keep the space at the end of the string - bug in az cli running on windows powershell truncates last char https://github.com/Azure/azure-cli/issues/10066
+$ADApplicationSecretKeyVault="@Microsoft.KeyVault(VaultName=$KeyVault;SecretName=ADApplicationSecret) "
+$DefaultConnectionKeyVault="@Microsoft.KeyVault(VaultName=$KeyVault;SecretName=DefaultConnection) "
 $ServerUri = $SQLServerName+".database.windows.net"
 $Connection="Data Source=tcp:"+$ServerUri+",1433;Initial Catalog=AMPSaaSDB;User Id="+$SQLAdminLogin+"@"+$SQLServerName+".database.windows.net;Password="+$SQLAdminLoginPassword+";"
 

--- a/deployment/Deploy.ps1
+++ b/deployment/Deploy.ps1
@@ -265,6 +265,9 @@ $WebAppNamePortal=$WebAppNamePrefix+"-portal"
 $KeyVault=$WebAppNamePrefix+"-kv"
 $KeyVault=$KeyVault -replace '_',''
 $ADApplicationSecretKeyVault='"@Microsoft.KeyVault(VaultName=' + $KeyVault+ ';SecretName=ADApplicationSecret)"'
+if ($PsVersionTable.Platform -ne 'Unix') {
+	$ADApplicationSecretKeyVault='@Microsoft.KeyVault(VaultName=' + $KeyVault+ ';SecretName=ADApplicationSecret)'
+}
 $DefaultConnectionKeyVault='"@Microsoft.KeyVault(VaultName=' + $KeyVault+ ';SecretName=DefaultConnection)"'
 $ServerUri = $SQLServerName+".database.windows.net"
 $Connection="Data Source=tcp:"+$ServerUri+",1433;Initial Catalog=AMPSaaSDB;User Id="+$SQLAdminLogin+"@"+$SQLServerName+".database.windows.net;Password="+$SQLAdminLoginPassword+";"


### PR DESCRIPTION
Fix an issue where running the script in PowerShell (windows) does not correctly set the KeyVault Reference due to a PowerShell bug.

The problem is specifically with the `az webapp config appsettings set` method when trying to set the value as a KeyVault reference (line 313) although it starts from how the `SaaSApiConfiguration__ClientSecret` value -`$ADApplicationSecretKeyVault`  is set on line 267

Example:
When setting the value like this: `$ADApplicationSecretKeyVault='"@Microsoft.KeyVault(VaultName=' + $KeyVault+ ';SecretName=ADApplicationSecret)"'`

The commad `az webapp config appsettings set` will:
1. work correctly on PowerShell 
    ![image](https://user-images.githubusercontent.com/8275679/207330020-d58dda04-9a5f-4e28-8f97-7c32e09c5995.png)
1. fail on CloudShell (notice the extra \" characters in the value)
    ![image](https://user-images.githubusercontent.com/8275679/207330192-882f8a31-86e3-420b-ad53-886ffa21724a.png)


When setting the value like this `$ADApplicationSecretKeyVault='@Microsoft.KeyVault(VaultName=' + $KeyVault+ ';SecretName=ADApplicationSecret)'` or like this `$ADApplicationSecretKeyVault="@Microsoft.KeyVault(VaultName=$KeyVault;SecretName=ADApplicationSecret)"`

The commad `az webapp config appsettings set ` will:
1. Fail on PowerShell (notice the missing ')' at the end of the value property)
    ![image](https://user-images.githubusercontent.com/8275679/207329202-b1526cfe-bcc6-40ed-8c57-9b9e10dc2b60.png)
1. Work correctly on Cloud Shell
    ![image](https://user-images.githubusercontent.com/8275679/207329796-03b71cd3-f00c-44d3-9634-a696bf3b33d9.png)

You can run this locally to test this (use sbtest3981 as your deployment name)
```powershell 
$WebAppNamePrefix="<existing-deployment-name>" 

$WebAppNamePortal=$WebAppNamePrefix+"-portal"
$ResourceGroupForDeployment = $WebAppNamePrefix
$KeyVault=$WebAppNamePrefix+"-kv"

$ADApplicationSecretKeyVault1='@Microsoft.KeyVault(VaultName=' + $KeyVault+ ';SecretName=ADApplicationSecret)'
$ADApplicationSecretKeyVault2="@Microsoft.KeyVault(VaultName=$KeyVault;SecretName=ADApplicationSecret)"
$ADApplicationSecretKeyVault3='"@Microsoft.KeyVault(VaultName=' + $KeyVault+ ';SecretName=ADApplicationSecret)"'

az webapp config appsettings set -g $ResourceGroupForDeployment  -n $WebAppNamePortal --settings SaaSApiConfiguration__ClientSecret=$ADApplicationSecretKeyVault1
```
If you run this from PowerShell (you must be authenticated using `az login` in the instance) you will see that the only way to have this work correctly is using `$ADApplicationSecretKeyVault3` option. However, in Azure CloudShell, `$ADApplicationSecretKeyVault3` won't work correctly and you need to use `$ADApplicationSecretKeyVault1` or `$ADApplicationSecretKeyVault2` options.



Note: What is very interesting is that even though almost identical, the `az webapp config connection-string set` that we use to set the ConnectionString, will accept either form (1,2,3) in either PowerShell or CloudShell and set this correctly.