### PR TITLE
Update the deploy to include a warning before closing the cloud shell

### DIFF
--- a/deployment/Deploy.ps1
+++ b/deployment/Deploy.ps1
@@ -370,4 +370,5 @@ Write-host "      ➡️ Tenant ID:                  $TenantID"
 Write-host "      ➡️ AAD Application ID section: $ADApplicationID"
 $duration = (Get-Date) - $startTime
 Write-Host "Deployment Complete in $($duration.Minutes)m:$($duration.Seconds)s"
+Write-Host "DO NOT CLOSE THIS SCREEN.  Please make sure you copy or perform the actions above before closing."
 #endregion


### PR DESCRIPTION
Update the deploy script to include a warning before closing the cloud shell as publishers are closing it before copying the proper field to Partner Center.