### PR TITLE
Refactor Admin - ApplicationConfigController

### DIFF
--- a/src/AdminSite/Controllers/ApplicationConfigController.cs
+++ b/src/AdminSite/Controllers/ApplicationConfigController.cs
@@ -18,6 +18,7 @@ namespace Marketplace.SaaS.Accelerator.AdminSite.Controllers;
 /// </summary>
 /// <seealso cref="BaseController" />
 [ServiceFilter(typeof(KnownUserAttribute))]
+[ServiceFilter(typeof(RequestLoggerActionFilter))]
 public class ApplicationConfigController : BaseController
 {
     private readonly ILogger<ApplicationConfigController> logger;
@@ -40,44 +41,34 @@ public class ApplicationConfigController : BaseController
     }
 
     /// <summary>
-    /// Indexes this instance.
+    /// Main action for Application Config Page
     /// </summary>
     /// <returns>return All Application Config.</returns>
+    [ServiceFilter(typeof(ExceptionHandlerAttribute))]
     public IActionResult Index()
     {
-        this.logger.LogInformation("Application Config Controller / Index");
-        try
-        {
-            IEnumerable<ApplicationConfiguration> getAllAppConfigData = new List<ApplicationConfiguration>();
-            getAllAppConfigData = this.appConfigService.GetAllApplicationConfiguration();
-            return this.View(getAllAppConfigData);
-        }
-        catch (Exception ex)
-        {
-            this.logger.LogError(ex, ex.Message);
-            return this.View("Error", ex);
-        }
+        this.logger.LogInformation("Application Config Controller / Index (from controller)");
+
+        IEnumerable<ApplicationConfiguration> getAllAppConfigData = new List<ApplicationConfiguration>();
+        getAllAppConfigData = this.appConfigService.GetAllApplicationConfiguration();
+        return this.View(getAllAppConfigData);
     }
 
     /// <summary>
     /// Indexes an EmailTemplate instance
     /// </summary>
     /// <returns>return a list of all EmailTemplates.</returns>
+    [ServiceFilter(typeof(ExceptionHandlerAttribute))]
     public IActionResult EmailTemplates()
     {
         this.logger.LogInformation("Application Config Controller / EmailTemplates");
-        try
-        {
-            IEnumerable<EmailTemplate> getEmailTemplateData = new List<EmailTemplate>();
-            getEmailTemplateData = this.emailTemplateRepository.GetAll();
-            return this.View(getEmailTemplateData);
-        }
-        catch (Exception ex)
-        {
-            this.logger.LogError(ex, ex.Message);
-            return this.View("Error", new Exception("Error loading templates." + Environment.NewLine + " Please check logs for more details."));
-        }
+
+        IEnumerable<EmailTemplate> getEmailTemplateData = new List<EmailTemplate>();
+        getEmailTemplateData = this.emailTemplateRepository.GetAll();
+        return this.View(getEmailTemplateData);
     }
+
+
 
     /// <summary>
     /// Get the fields of an EmailTemplate item by status
@@ -89,17 +80,10 @@ public class ApplicationConfigController : BaseController
     public IActionResult EmailTemplateDetails(string status)
     {
         this.logger.LogInformation("ApplicationConfig Controller / EmailTemplateDetails:  Status {0}", status);
-        try
-        {
-            EmailTemplate emailTemplate = new EmailTemplate();
-            emailTemplate = this.emailTemplateRepository.GetTemplateForStatus(status);
-            return this.PartialView(emailTemplate);
-        }
-        catch (Exception ex)
-        {
-            this.logger.LogError(ex, ex.Message);
-            return this.View("Error", ex);
-        }
+
+        EmailTemplate emailTemplate = new EmailTemplate();
+        emailTemplate = this.emailTemplateRepository.GetTemplateForStatus(status);
+        return this.PartialView(emailTemplate);
     }
 
     /// <summary>
@@ -113,21 +97,14 @@ public class ApplicationConfigController : BaseController
     public IActionResult EmailTemplateDetails(EmailTemplate emailTemplate)
     {
         this.logger.LogInformation("ApplicationConfig Controller / EmailTemplateDetails:  EmailTemplate {0}", JsonSerializer.Serialize(emailTemplate));
-        try
-        {
-            if (emailTemplate != null)
-            {
-                this.emailTemplateRepository.SaveEmailTemplateByStatus(emailTemplate);
-            }
 
-            this.ModelState.Clear();
-            return this.RedirectToAction(nameof(this.EmailTemplateDetails), new { status = emailTemplate.Status });
-        }
-        catch (Exception ex)
+        if (emailTemplate != null)
         {
-            this.logger.LogError(ex, ex.Message);
-            return this.PartialView("Error", ex);
+            this.emailTemplateRepository.SaveEmailTemplateByStatus(emailTemplate);
         }
+
+        this.ModelState.Clear();
+        return this.RedirectToAction(nameof(this.EmailTemplateDetails), new { status = emailTemplate.Status });
     }
 
 
@@ -142,18 +119,12 @@ public class ApplicationConfigController : BaseController
     public IActionResult ApplicationConfigDetails(int Id)
     {
         this.logger.LogInformation("ApplicationConfig Controller / AppConfigDetails:  Id {0}", Id);
-        try
-        {
-            ApplicationConfiguration applicationConfiguration = new ApplicationConfiguration();
-            applicationConfiguration = this.appConfigService.GetById(Id);
-            return this.PartialView(applicationConfiguration);
-        }
-        catch (Exception ex)
-        {
-            this.logger.LogError(ex, ex.Message);
-            return this.View("Error", ex);
-        }
+
+        ApplicationConfiguration applicationConfiguration = new ApplicationConfiguration();
+        applicationConfiguration = this.appConfigService.GetById(Id);
+        return this.PartialView(applicationConfiguration);
     }
+
 
     /// <summary>
     /// Saves the app config item changes.
@@ -166,22 +137,15 @@ public class ApplicationConfigController : BaseController
     public IActionResult ApplicationConfigDetails(ApplicationConfiguration appConfig)
     {
         this.logger.LogInformation("ApplicationConfig Controller / ApplicationConfigDetails:  AppConfig {0}", JsonSerializer.Serialize(appConfig));
-        try
+        if (appConfig != null)
         {
-            if (appConfig != null)
-            {
-                this.appConfigService.SaveAppConfig(appConfig);
-            }
+            this.appConfigService.SaveAppConfig(appConfig);
+        }
 
-            this.ModelState.Clear();
-            return this.RedirectToAction(nameof(this.ApplicationConfigDetails), new { Id = appConfig.Id });
-        }
-        catch (Exception ex)
-        {
-            this.logger.LogError(ex, ex.Message);
-            return this.PartialView("Error", ex);
-        }
+        this.ModelState.Clear();
+        return this.RedirectToAction(nameof(this.ApplicationConfigDetails), new { Id = appConfig.Id });
     }
+
 
     /// <summary>
     /// Upload file(s) to database
@@ -189,78 +153,70 @@ public class ApplicationConfigController : BaseController
     /// <param name="files">The files</param>
     /// <returns>RedirectToAction.</returns>
     [HttpPost("FileUpload")]
+    [ServiceFilter(typeof(ExceptionHandlerAttribute))]
     public IActionResult PostUpload(List<IFormFile> files)
     {
         this.logger.LogInformation("Application Config Controller / PostUpload ");
-        try
+        if (files == null || files.Count == 0)
         {
-            if (files == null || files.Count == 0)
+            TempData["Upload"] = "No files to upload";
+            return RedirectToAction("Index");
+        }
+        else
+        {
+            if (files.Count > 2)
             {
-                TempData["Upload"] = "No files to upload";
+                TempData["Upload"] = "No more than two files can be uploaded";
                 return RedirectToAction("Index");
+            }
+            foreach (var file in files)
+            {
+                int maxLength = 1024 * 1024 * 5; //5 MB
+
+                if (file.Length > maxLength)
+                {
+                    TempData["Upload"] = "File is too large, max size of file for upload is 5 MB";
+                    return RedirectToAction("Index");
+                }
+                if (file.Length == 0)
+                {
+                    TempData["Upload"] = "File is empty";
+                    return RedirectToAction("Index");
+                }
+
+                var fileExtension = Path.GetExtension(file.FileName).ToLowerInvariant();
+
+                if (fileExtension != ".png" && fileExtension != ".ico")
+                {
+                    TempData["Upload"] = "Only .png or .ico files can be uploaded";
+                    return RedirectToAction("Index");
+                }
+
+                var appConfigNames = this.appConfigService.GetAllApplicationConfiguration().Select(a => a.Name);
+
+                if (!appConfigNames.Contains("LogoFile") || !appConfigNames.Contains("FaviconFile"))
+                {
+                    TempData["Upload"] = "LogoFile or FaviconFile application config settings are missing in the database";
+                    return RedirectToAction("Index");
+                }
+
+                if (this.appConfigService.UploadFileToDatabase(file, fileExtension) == false)
+                {
+                    TempData["Upload"] = "File Upload failed!";
+                    return RedirectToAction("Index");
+                }
+            }
+
+            if (files.Count == 1)
+            {
+                TempData["Upload"] = files.FirstOrDefault().FileName + "  uploaded successfully";
             }
             else
             {
-                if (files.Count > 2)
-                {
-                    TempData["Upload"] = "No more than two files can be uploaded";
-                    return RedirectToAction("Index");
-                }       
-                foreach (var file in files)
-                {
-                    int maxLength = 1024 * 1024 * 5; //5 MB
-
-                    if (file.Length > maxLength)
-                    {
-                        TempData["Upload"] = "File is too large, max size of file for upload is 5 MB";
-                        return RedirectToAction("Index");
-                    }
-                    if (file.Length == 0)
-                    {
-                        TempData["Upload"] = "File is empty";
-                        return RedirectToAction("Index");
-                    }
-
-                    var fileExtension = Path.GetExtension(file.FileName).ToLowerInvariant();
-
-                    if (fileExtension != ".png" && fileExtension != ".ico")
-                    {
-                        TempData["Upload"] = "Only .png or .ico files can be uploaded";
-                        return RedirectToAction("Index");
-                    }
-
-                    var appConfigNames = this.appConfigService.GetAllApplicationConfiguration().Select(a => a.Name);
-                       
-                    if (!appConfigNames.Contains("LogoFile") || !appConfigNames.Contains("FaviconFile"))
-                    {
-                        TempData["Upload"] = "LogoFile or FaviconFile application config settings are missing in the database";
-                        return RedirectToAction("Index");
-                    }
-
-                    if (this.appConfigService.UploadFileToDatabase(file, fileExtension) == false)
-                    {
-                        TempData["Upload"] = "File Upload failed!";
-                        return RedirectToAction("Index");
-                    }
-                }
-
-                if (files.Count == 1)
-                {
-                    TempData["Upload"] = files.FirstOrDefault().FileName + "  uploaded successfully";
-                }
-                else
-                {
-                    TempData["Upload"] = files[0].FileName + " and " + files[1].FileName + " uploaded successfully";
-                }
+                TempData["Upload"] = files[0].FileName + " and " + files[1].FileName + " uploaded successfully";
             }
-            return RedirectToAction("Index");
         }
-        catch (Exception ex)
-        {
-            this.logger.LogError(ex, ex.Message);
-            TempData["Upload"] = "File Upload failed!";
-            return this.PartialView("Error", ex);
-        }
+        return RedirectToAction("Index");
     }
 
 }

--- a/src/AdminSite/Controllers/ApplicationConfigController.cs
+++ b/src/AdminSite/Controllers/ApplicationConfigController.cs
@@ -104,7 +104,7 @@ public class ApplicationConfigController : BaseController
         }
 
         this.ModelState.Clear();
-        return this.RedirectToAction(nameof(this.EmailTemplateDetails), new { status = emailTemplate.Status });
+        return new OkResult();
     }
 
 
@@ -143,7 +143,7 @@ public class ApplicationConfigController : BaseController
         }
 
         this.ModelState.Clear();
-        return this.RedirectToAction(nameof(this.ApplicationConfigDetails), new { Id = appConfig.Id });
+        return new OkResult();
     }
 
 

--- a/src/AdminSite/Controllers/ApplicationConfigController.cs
+++ b/src/AdminSite/Controllers/ApplicationConfigController.cs
@@ -23,21 +23,21 @@ public class ApplicationConfigController : BaseController
 {
     private readonly ILogger<ApplicationConfigController> logger;
 
-    private ApplicationConfigService appConfigService;
-
-    private readonly IApplicationConfigRepository appConfigRepository;
+    private readonly ApplicationConfigService appConfigService;
 
     /// <summary>
     /// Move to a new controller?
     /// </summary>
     private readonly IEmailTemplateRepository emailTemplateRepository;
 
-    public ApplicationConfigController(IApplicationConfigRepository applicationConfigRepository, ILogger<ApplicationConfigController> logger, IEmailTemplateRepository emailTemplateRepository)
+    public ApplicationConfigController(
+        ApplicationConfigService appConfigService, 
+        ILogger<ApplicationConfigController> logger, 
+        IEmailTemplateRepository emailTemplateRepository)
     {
-        this.appConfigRepository = applicationConfigRepository;
+        this.appConfigService = appConfigService;
         this.emailTemplateRepository = emailTemplateRepository;
         this.logger = logger;
-        appConfigService = new ApplicationConfigService(this.appConfigRepository);
     }
 
     /// <summary>

--- a/src/AdminSite/Program.cs
+++ b/src/AdminSite/Program.cs
@@ -19,6 +19,7 @@ public class Program
         var loggerFactory = LoggerFactory.Create(builder =>
         {
             builder
+                .AddDebug()
                 .AddConsole();
         });
 
@@ -37,6 +38,7 @@ public class Program
             {
                 logging.ClearProviders();
                 logging.AddConsole();
+                logging.AddDebug();
             })
             .ConfigureWebHostDefaults(webBuilder =>
             {

--- a/src/AdminSite/Startup.cs
+++ b/src/AdminSite/Startup.cs
@@ -117,6 +117,10 @@ public class Startup
             .AddSingleton<KnownUsersModel>(knownUsers);
 
         services
+            .AddScoped<ApplicationConfigService>()
+        ;
+
+        services
             .AddDbContext<SaasKitContext>(options => options.UseSqlServer(this.Configuration.GetConnectionString("DefaultConnection")));
 
 

--- a/src/AdminSite/Startup.cs
+++ b/src/AdminSite/Startup.cs
@@ -57,12 +57,6 @@ public class Startup
     /// <param name="services">The services.</param>
     public void ConfigureServices(IServiceCollection services)
     {
-        var loggerFactory = LoggerFactory.Create(builder =>
-        {
-            builder
-                .AddConsole();
-        });
-
         services.Configure<CookiePolicyOptions>(options =>
         {
             // This lambda determines whether user consent for non-essential cookies is needed for a given request.
@@ -112,8 +106,10 @@ public class Startup
             .AddCookie();
 
         services
-            .AddTransient<IClaimsTransformation, CustomClaimsTransformation>();
-
+            .AddTransient<IClaimsTransformation, CustomClaimsTransformation>()
+            .AddScoped<ExceptionHandlerAttribute>()
+            .AddScoped<RequestLoggerActionFilter>()
+        ;
         services
             .AddSingleton<IFulfillmentApiService>(new FulfillmentApiService(new MarketplaceSaaSClient(creds), config, new FulfillmentApiClientLogger()))
             .AddSingleton<IMeteredBillingApiService>(new MeteredBillingApiService(new MarketplaceMeteringClient(creds), config, new MeteringApiClientLogger()))
@@ -127,7 +123,8 @@ public class Startup
         InitializeRepositoryServices(services);
 
         services.AddDistributedMemoryCache();
-        services.AddSession(options => {
+        services.AddSession(options =>
+        {
             options.IdleTimeout = TimeSpan.FromMinutes(5);
             options.Cookie.HttpOnly = true;
             options.Cookie.IsEssential = true;
@@ -136,7 +133,8 @@ public class Startup
         services.AddMvc(option => option.EnableEndpointRouting = false);
         services.AddControllersWithViews();
 
-        services.Configure<CookieTempDataProviderOptions>(options => {
+        services.Configure<CookieTempDataProviderOptions>(options =>
+        {
             options.Cookie.IsEssential = true;
         });
     }

--- a/src/AdminSite/Views/ApplicationConfig/ApplicationConfigDetails.cshtml
+++ b/src/AdminSite/Views/ApplicationConfig/ApplicationConfigDetails.cshtml
@@ -1,39 +1,31 @@
 ﻿@model Marketplace.SaaS.Accelerator.DataAccess.Entities.ApplicationConfiguration
-<head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link href="~/css/jquery-ui/jquery-ui.css" rel="stylesheet" />
-    <link href="~/css/jquery-ui/style.css" rel="stylesheet" />
-    <script src="~/lib/jquery-ui/jquery-1.12.4.js"></script>
-    <script src="~/lib/jquery-ui/jquery-ui.js"></script>
-</head>
-<body>
 
-    <div class="text-center mt20">
-        <div class="card card-header">
-            <dl class="row">
-                <dt class="col-2 text-right"><span>Edit App Config</span></dt>
-            </dl>
+
+<div class="text-center mt20">
+    <div class="card card-header">
+        <dl class="row">
+            <dt class="col-2 text-right"><span>Edit App Config</span></dt>
+        </dl>
+    </div>
+    <form method="post" id="frmAppConfigDetails" asp-action="ApplicationConfigDetails" asp-controller="ApplicationConfig">
+        <div>
+            @Html.HiddenFor(model => model.Id)
         </div>
-        <form method="post" id="frmAppConfigDetails" asp-action="ApplicationConfigDetails" asp-controller="ApplicationConfig">
-            <div>
-                @Html.HiddenFor(model => model.Id)
-            </div>
-            <table class="table table-bordered dt-responsive cm-table" id="tblcontainer">
-                <theader>
-                    <tr>
-                        <th>Name</th>
-                        <th>Value</th>
-                        <th>Description</th>
-                    </tr>
-                </theader>
-                <tbody>
+        <table class="table table-bordered dt-responsive cm-table" id="tblcontainer">
+            <theader>
+                <tr>
+                    <th>Name</th>
+                    <th>Value</th>
+                    <th>Description</th>
+                </tr>
+            </theader>
+            <tbody>
                 <tr>
                     <td>
                         @Model.Name
                     </td>
                     <td>
-                        @if (@Model.Name.Equals("SMTPPassword") && @Model.Value.Length >5)
+                        @if (@Model.Name.Equals("SMTPPassword") && @Model.Value.Length > 5)
                         {
                             @Html.EditorFor(model => model.Value, new { htmlAttributes = new { type ="password", @class = "form-control" } })
                         }
@@ -46,37 +38,19 @@
                         @Html.EditorFor(model => model.Description,new { htmlAttributes = new { @class = "form-control" } })
                     </td>
                 </tr>
-                </tbody>
-            </table>
-            <div class="ac-save-d">
-                <p>
-                    <a class="cm-button-default mt0" id="backButton" asp-area="" asp-controller="ApplicationConfig" asp-action="Index">Back</a>
-                    <input class="cm-button-default mt0 ac-save-i" type="button" onclick="saveAppConfigDetails()" value="Save App Config" />
-                </p>
-            </div>
-        </form>
-    </div>
+            </tbody>
+        </table>
+        <div class="ac-save-d">
+            <p>
+                <a class="cm-button-default mt0" id="backButton" asp-area="" asp-controller="ApplicationConfig" asp-action="Index">Back</a>
+                <input class="cm-button-default mt0 ac-save-i" type="button" onclick="saveAppConfigDetails()" value="Save App Config" />
+            </p>
+        </div>
+    </form>
+</div>
 
-
-</body>
 <script>
 
-    function successconfirmDialog() {
-        swal({
-            title: "Saved",
-            text: "App config details saved successfully.",
-            icon: "success",
-            timer: 1000
-        })
-    }
-    function errorconfirmDialog() {
-        swal({
-            title: "Error",
-            text: "An error has occured, please check the log.",
-            icon: "error",
-            timer: 1000
-        })
-    }
     function saveAppConfigDetails() {
         var formobject = $('#frmAppConfigDetails').serialize();
         $.ajax({
@@ -86,13 +60,20 @@
             cache: false,
             success: function (result) {
                 debugger;
-                successconfirmDialog();
-                $('#myModal').html(result);
+                swal({
+                    title: "Saved",
+                    text: "App config details saved successfully.",
+                    icon: "success",
+                    timer: 1000
+                })
             },
             Error:
                 function (result) {
-                    errorconfirmDialog();
-                    $('#myModal').html(result);
+                     swal({
+                        title: "Error",
+                        text: "An error has occured, please check the log.",
+                        icon: "error"
+                    })
                 }
         });
     }

--- a/src/AdminSite/Views/ApplicationConfig/EmailTemplateDetails.cshtml
+++ b/src/AdminSite/Views/ApplicationConfig/EmailTemplateDetails.cshtml
@@ -1,95 +1,69 @@
 ﻿@model Marketplace.SaaS.Accelerator.DataAccess.Entities.EmailTemplate
-<head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link href="~/css/jquery-ui/jquery-ui.css" rel="stylesheet" />
-    <link href="~/css/jquery-ui/style.css" rel="stylesheet" />
-    <script src="~/lib/jquery-ui/jquery-1.12.4.js"></script>
-    <script src="~/lib/jquery-ui/jquery-ui.js"></script>
-</head>
-<body>
-    <div class="text-center mt20">
-        <div class="card card-header">
-            <dl class="row">
-                <dt class="col-2 text-right"><span>Edit Email Template</span></dt>
-            </dl>
-        </div>
-        <form method="post" id="frmEmailTemplateDetails" asp-action="EmailTemplateDetails" asp-controller="ApplicationConfig">
-            <div>
-                @Html.HiddenFor(model => model.Status)
-            </div>
-            <div>
-                @Html.HiddenFor(model => model.Id)
-            </div>
-            <table class="table table-bordered dt-responsive cm-table" id="tblcontainer">
-                <theader>
-                    <tr>
-                        <th class="text-left">Field</th>
-                        <th class="text-left">Value</th>
-                    </tr>
-                </theader>
-                <tbody>
-                     <tr>
-                        <td class="text-left">IsActive</td>
-                        <td class="text-left">@Html.CheckBoxFor(model => model.IsActive, new { htmlAttributes = new { type ="checkbox", @class = "float-left", name="IsActive" } })</td>
-                    </tr>
-                     <tr>
-                        <td class="text-left">Subject</td>
-                        <td class="text-left">@Html.EditorFor(model => model.Subject, new { htmlAttributes = new {  @class = "form-control", name="Subject" } })</td>
-                    </tr>
-                     <tr>
-                        <td class="text-left">Description</td>
-                        <td class="text-left">@Html.EditorFor(model => model.Description, new { htmlAttributes = new { @class = "form-control", name="Description" } })</td>
-                    </tr>
-                     <tr>
-                        <td class="text-left">TemplateBody</td>
-                        <td class="text-left">@Html.TextAreaFor(model => model.TemplateBody, new { @class = "form-control" })
-                            <span class="font-italic hint-text text-left">Due to the content size, it is recommended to copy the content to an external editor, modify the Template body, paste it back into here and save.</span>
-                        </td>
-                    </tr>
-                     <tr>
-                        <td class="text-left">ToRecipients</td>
-                        <td class="text-left">@Html.EditorFor(model => model.ToRecipients, new { htmlAttributes = new { @class = "form-control", name="ToRecipients" } })</td>
-                    </tr>
-                     <tr>
-                        <td class="text-left">Bcc</td>
-                        <td class="text-left">@Html.EditorFor(model => model.Bcc, new { htmlAttributes = new { @class = "form-control", name="Bcc" } })</td>
-                    </tr>
-                     <tr>
-                        <td class="text-left">Cc</td>
-                        <td class="text-left">@Html.EditorFor(model => model.Cc, new { htmlAttributes = new { @class = "form-control", name="Cc" } })</td>
-                    </tr>         
-                </tbody>
-            </table>
-            <div class="ac-save-d">
-                <p>
-                    <a class="cm-button-default mt0" id="backButton" asp-area="" asp-controller="ApplicationConfig" asp-action="EmailTemplates">Back</a>
-                    <input class="cm-button-default mt0 ac-save-i" type="button" onclick="saveEmailTemplateDetails()" value="Save Template" />
-                </p>
-            </div>
-        </form>
+<div class="text-center mt20">
+    <div class="card card-header">
+        <dl class="row">
+            <dt class="col-2 text-right"><span>Edit Email Template</span></dt>
+        </dl>
     </div>
+    <form method="post" id="frmEmailTemplateDetails" asp-action="EmailTemplateDetails" asp-controller="ApplicationConfig">
+        <div>
+            @Html.HiddenFor(model => model.Status)
+        </div>
+        <div>
+            @Html.HiddenFor(model => model.Id)
+        </div>
+        <table class="table table-bordered dt-responsive cm-table" id="tblcontainer">
+            <theader>
+                <tr>
+                    <th class="text-left">Field</th>
+                    <th class="text-left">Value</th>
+                </tr>
+            </theader>
+            <tbody>
+                <tr>
+                    <td class="text-left">IsActive</td>
+                    <td class="text-left">@Html.CheckBoxFor(model => model.IsActive, new { htmlAttributes = new { type ="checkbox", @class = "float-left", name="IsActive" } })</td>
+                </tr>
+                <tr>
+                    <td class="text-left">Subject</td>
+                    <td class="text-left">@Html.EditorFor(model => model.Subject, new { htmlAttributes = new {  @class = "form-control", name="Subject" } })</td>
+                </tr>
+                <tr>
+                    <td class="text-left">Description</td>
+                    <td class="text-left">@Html.EditorFor(model => model.Description, new { htmlAttributes = new { @class = "form-control", name="Description" } })</td>
+                </tr>
+                <tr>
+                    <td class="text-left">TemplateBody</td>
+                    <td class="text-left">
+                        @Html.TextAreaFor(model => model.TemplateBody, new { @class = "form-control" })
+                        <span class="font-italic hint-text text-left">Due to the content size, it is recommended to copy the content to an external editor, modify the Template body, paste it back into here and save.</span>
+                    </td>
+                </tr>
+                <tr>
+                    <td class="text-left">ToRecipients</td>
+                    <td class="text-left">@Html.EditorFor(model => model.ToRecipients, new { htmlAttributes = new { @class = "form-control", name="ToRecipients" } })</td>
+                </tr>
+                <tr>
+                    <td class="text-left">Bcc</td>
+                    <td class="text-left">@Html.EditorFor(model => model.Bcc, new { htmlAttributes = new { @class = "form-control", name="Bcc" } })</td>
+                </tr>
+                <tr>
+                    <td class="text-left">Cc</td>
+                    <td class="text-left">@Html.EditorFor(model => model.Cc, new { htmlAttributes = new { @class = "form-control", name="Cc" } })</td>
+                </tr>
+            </tbody>
+        </table>
+        <div class="ac-save-d">
+            <p>
+                <a class="cm-button-default mt0" id="backButton" asp-area="" asp-controller="ApplicationConfig" asp-action="EmailTemplates">Back</a>
+                <input class="cm-button-default mt0 ac-save-i" type="button" onclick="saveEmailTemplateDetails()" value="Save Template" />
+            </p>
+        </div>
+    </form>
+</div>
 
-
-</body>
 <script>
 
-    function successconfirmDialog() {
-        swal({
-            title: "Saved",
-            text: "Email Template saved successfully.",
-            icon: "success",
-            timer: 1000
-        })
-    }
-    function errorconfirmDialog() {
-        swal({
-            title: "Error",
-            text: "An error has occured, please check the log.",
-            icon: "error",
-            timer: 1000
-        })
-    }
     function saveEmailTemplateDetails() {
         var formobject = $('#frmEmailTemplateDetails').serialize();
         $.ajax({
@@ -99,13 +73,20 @@
             cache: false,
             success: function (result) {
                 debugger;
-                successconfirmDialog();
-                $('#emailTemplateModal').html(result);
+                swal({
+                    title: "Saved",
+                    text: "Email Template saved successfully.",
+                    icon: "success",
+                    timer: 1000
+                });
             },
             Error:
                 function (result) {
-                    errorconfirmDialog();
-                    $('#emailTemplateModal').html(result);
+                    swal({
+                        title: "Error",
+                        text: "An error has occured, please check the log.",
+                        icon: "error"
+                    });
                 }
         });
     }

--- a/src/AdminSite/Views/ApplicationConfig/EmailTemplates.cshtml
+++ b/src/AdminSite/Views/ApplicationConfig/EmailTemplates.cshtml
@@ -98,7 +98,11 @@
                 $('#emailTemplatesModal').html(data);
             },
             error: function () {
-                alert("Content load failed.");
+                 swal({
+                        title: "Error",
+                        text: "An error has occured, while loading details.",
+                        icon: "error"
+                    });
             }
         });
     }

--- a/src/AdminSite/Views/ApplicationConfig/Index.cshtml
+++ b/src/AdminSite/Views/ApplicationConfig/Index.cshtml
@@ -106,10 +106,13 @@
                 datatype: "json",
                 success: function (data) {
                     $('#myModal').html(data);
-                    //$('#myModal').modal();
                 },
                 error: function () {
-                    alert("Content load failed.");
+                    swal({
+                        title: "Error",
+                        text: "An error has occured, while loading details.",
+                        icon: "error"
+                    });
                 }
             });
         }

--- a/src/CustomerSite/Program.cs
+++ b/src/CustomerSite/Program.cs
@@ -19,6 +19,7 @@ public class Program
         var loggerFactory = LoggerFactory.Create(builder =>
         {
             builder
+                .AddDebug()
                 .AddConsole();
         });
 
@@ -37,6 +38,7 @@ public class Program
             {
                 logging.ClearProviders();
                 logging.AddConsole();
+                logging.AddDebug();
             })
             .ConfigureWebHostDefaults(webBuilder =>
             {

--- a/src/CustomerSite/Startup.cs
+++ b/src/CustomerSite/Startup.cs
@@ -52,12 +52,6 @@ public class Startup
     /// <param name="services">The services<see cref="IServiceCollection"/>.</param>
     public void ConfigureServices(IServiceCollection services)
     {
-        var loggerFactory = LoggerFactory.Create(builder =>
-        {
-            builder
-                .AddConsole();
-        });
-
         services.Configure<CookiePolicyOptions>(options =>
         {
             // This lambda determines whether user consent for non-essential cookies is needed for a given request.
@@ -101,7 +95,10 @@ public class Startup
                 options.TokenValidationParameters.ValidateIssuer = false;
             });
         services
-            .AddTransient<IClaimsTransformation, CustomClaimsTransformation>();
+            .AddTransient<IClaimsTransformation, CustomClaimsTransformation>()
+            .AddScoped<ExceptionHandlerAttribute>()
+            .AddScoped<RequestLoggerActionFilter>()
+        ;
 
         services
             .AddSingleton<IFulfillmentApiService>(new FulfillmentApiService(new MarketplaceSaaSClient(creds), config, new FulfillmentApiClientLogger()))

--- a/src/Services/Utilities/ExceptionHandlerAttribute.cs
+++ b/src/Services/Utilities/ExceptionHandlerAttribute.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Marketplace.SaaS.Accelerator.Services.Utilities;
+public class ExceptionHandlerAttribute : ExceptionFilterAttribute
+{
+    private readonly ILogger<ExceptionHandlerAttribute> _logger;
+    private readonly IModelMetadataProvider _modelMetadataProvider;
+    public ExceptionHandlerAttribute(IModelMetadataProvider modelMetadataProvider, ILogger<ExceptionHandlerAttribute> logger)
+    {
+        _modelMetadataProvider = modelMetadataProvider;
+        _logger = logger;
+    }
+
+    public override void OnException(ExceptionContext context)
+    {
+        base.OnException(context);
+        _logger.LogError(context.Exception, $"Exception: {context.Exception.Message} - {context.Exception.InnerException?.Message ?? ""}");
+
+
+        var result = new ViewResult
+        {
+            ViewName = "Error",
+            ViewData = new ViewDataDictionary(_modelMetadataProvider, context.ModelState)
+            {
+                Model = context.Exception
+            }
+        };
+
+        context.ExceptionHandled = true; // mark exception as handled
+        context.Result = result;
+    }
+}

--- a/src/Services/Utilities/RequestLoggerActionFilter.cs
+++ b/src/Services/Utilities/RequestLoggerActionFilter.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace Marketplace.SaaS.Accelerator.Services.Utilities;
+public class RequestLoggerActionFilter : IAsyncActionFilter
+{
+    private readonly ILogger<RequestLoggerActionFilter> _logger;
+    public RequestLoggerActionFilter(ILogger<RequestLoggerActionFilter> logger)
+    {
+        _logger = logger;
+    }
+   
+    public async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
+    {
+        var controllerContext = context.ActionDescriptor as ControllerActionDescriptor;
+        if (controllerContext == null)
+        {
+            _logger.LogInformation($"Executing {context.ActionDescriptor.ToString()}");
+        }
+        else
+        {
+            var parametersValue = context.ActionArguments.Select(arg => $"{arg.Key}:{JsonSerializer.Serialize(arg.Value)}");
+            var parametersString = parametersValue.Any() ? $"Parameters: {string.Join("::", parametersValue)}" : string.Empty;
+
+            _logger.LogInformation($"Executing {controllerContext.ControllerName} / {controllerContext.ActionName}. {parametersString}");
+        }
+
+        await next();
+    }
+
+}


### PR DESCRIPTION
Added new ActionFilters
- Error Handler filter to inject in controllers as needed
- Request Log Filter to inject in controllers
- Register as services in both customer and admin portals
- Add logging providers for debugging

Refactor ApplicationConfigController
- Implement request logging filter
- remove redundant log statements and simplify controller methods
- Get Service from DI instead of building it in the controller ctor
- fix PartialViews to only show Partial View Content (div and not body)
- update error messages to use swal instead of alert
- introduce Error middleware (Cannot apply at top level of controller due to mix of controller methods (some returning a View, some PartialView and some doing redirects). Errors are handled in the cshtml for those)
- fixes a bug where the try/catch in methods returning PartialView (ApplicationConfigDetails, EmailTemplateDetails) displays error page in modal (looks bad).