### PR TITLE
Passed fulfilment base url to Marketplace SaaS client

### DIFF
--- a/src/AdminSite/Startup.cs
+++ b/src/AdminSite/Startup.cs
@@ -111,7 +111,10 @@ public class Startup
             .AddScoped<RequestLoggerActionFilter>()
         ;
 
-        var fulfillmentBaseApi = new Uri(config.FulFillmentAPIBaseURL ?? "https://marketplaceapi.microsoft.com/api");
+        if (!Uri.TryCreate(config.FulFillmentAPIBaseURL, UriKind.Absolute, out var fulfillmentBaseApi))
+        {
+            fulfillmentBaseApi = new Uri("https://marketplaceapi.microsoft.com/api");
+        }
 
         services
             .AddSingleton<IFulfillmentApiService>(new FulfillmentApiService(new MarketplaceSaaSClient(fulfillmentBaseApi, creds), config, new FulfillmentApiClientLogger()))

--- a/src/AdminSite/Startup.cs
+++ b/src/AdminSite/Startup.cs
@@ -110,8 +110,11 @@ public class Startup
             .AddScoped<ExceptionHandlerAttribute>()
             .AddScoped<RequestLoggerActionFilter>()
         ;
+
+        var fulfillmentBaseApi = new Uri(config.FulFillmentAPIBaseURL ?? "https://marketplaceapi.microsoft.com/api");
+
         services
-            .AddSingleton<IFulfillmentApiService>(new FulfillmentApiService(new MarketplaceSaaSClient(creds), config, new FulfillmentApiClientLogger()))
+            .AddSingleton<IFulfillmentApiService>(new FulfillmentApiService(new MarketplaceSaaSClient(fulfillmentBaseApi, creds), config, new FulfillmentApiClientLogger()))
             .AddSingleton<IMeteredBillingApiService>(new MeteredBillingApiService(new MarketplaceMeteringClient(creds), config, new MeteringApiClientLogger()))
             .AddSingleton<SaaSApiClientConfiguration>(config)
             .AddSingleton<KnownUsersModel>(knownUsers);

--- a/src/CustomerSite/Startup.cs
+++ b/src/CustomerSite/Startup.cs
@@ -24,6 +24,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using Microsoft.Marketplace.SaaS;
+using System;
 
 namespace Marketplace.SaaS.Accelerator.CustomerSite;
 
@@ -100,8 +101,10 @@ public class Startup
             .AddScoped<RequestLoggerActionFilter>()
         ;
 
+        var fulfillmentBaseApi = new Uri(config.FulFillmentAPIBaseURL ?? "https://marketplaceapi.microsoft.com/api");
+
         services
-            .AddSingleton<IFulfillmentApiService>(new FulfillmentApiService(new MarketplaceSaaSClient(creds), config, new FulfillmentApiClientLogger()))
+            .AddSingleton<IFulfillmentApiService>(new FulfillmentApiService(new MarketplaceSaaSClient(fulfillmentBaseApi, creds), config, new FulfillmentApiClientLogger()))
             .AddSingleton<SaaSApiClientConfiguration>(config);
 
         services

--- a/src/CustomerSite/Startup.cs
+++ b/src/CustomerSite/Startup.cs
@@ -101,7 +101,14 @@ public class Startup
             .AddScoped<RequestLoggerActionFilter>()
         ;
 
-        var fulfillmentBaseApi = new Uri(config.FulFillmentAPIBaseURL ?? "https://marketplaceapi.microsoft.com/api");
+        var fulfillmentAPIBaseURL = config.FulFillmentAPIBaseURL;
+
+        if (string.IsNullOrWhiteSpace(fulfillmentAPIBaseURL))
+        {
+            fulfillmentAPIBaseURL = "https://marketplaceapi.microsoft.com/api";
+        }
+
+        var fulfillmentBaseApi = new Uri(fulfillmentAPIBaseURL);
 
         services
             .AddSingleton<IFulfillmentApiService>(new FulfillmentApiService(new MarketplaceSaaSClient(fulfillmentBaseApi, creds), config, new FulfillmentApiClientLogger()))

--- a/src/CustomerSite/Startup.cs
+++ b/src/CustomerSite/Startup.cs
@@ -101,14 +101,10 @@ public class Startup
             .AddScoped<RequestLoggerActionFilter>()
         ;
 
-        var fulfillmentAPIBaseURL = config.FulFillmentAPIBaseURL;
-
-        if (string.IsNullOrWhiteSpace(fulfillmentAPIBaseURL))
+        if (!Uri.TryCreate(config.FulFillmentAPIBaseURL, UriKind.Absolute, out var fulfillmentBaseApi)) 
         {
-            fulfillmentAPIBaseURL = "https://marketplaceapi.microsoft.com/api";
+            fulfillmentBaseApi = new Uri("https://marketplaceapi.microsoft.com/api");
         }
-
-        var fulfillmentBaseApi = new Uri(fulfillmentAPIBaseURL);
 
         services
             .AddSingleton<IFulfillmentApiService>(new FulfillmentApiService(new MarketplaceSaaSClient(fulfillmentBaseApi, creds), config, new FulfillmentApiClientLogger()))


### PR DESCRIPTION
There is a configuration setting to allow the base url for the sass fulfilment api to be changed from the default, but the value was never used.