### PR TITLE
Corrected Suspend status in SubscriptionStatusEnumExtension.cs

### DIFF
--- a/src/Services/Models/SubscriptionStatusEnumExtension.cs
+++ b/src/Services/Models/SubscriptionStatusEnumExtension.cs
@@ -46,7 +46,7 @@ public enum SubscriptionStatusEnumExtension
     UnsubscribeFailed,
 
     /// <summary>
-    /// The Suspend 
+    /// The Suspended 
     /// </summary>
-    Suspend,
+    Suspended,
 }


### PR DESCRIPTION
The SubscriptionStatusEnumExtension enum incorrectly contains 'Suspend' as a state for a subscription.  According to the documentation (https://learn.microsoft.com/en-us/azure/marketplace/partner-center-portal/pc-saas-fulfillment-subscription-api) this should be 'Suspended'.

With an incorrect state in the enum, the accelerator UI reports the subscription status as 'UnRecognized' as the TryParse operation on the enum cannot locate the string passed from the API.