### PR TITLE
update dotnet-ef version from 3.1.2 to 6.0

### DIFF
--- a/src/AdminSite/.config/dotnet-tools.json
+++ b/src/AdminSite/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "dotnet-ef": {
-      "version": "3.1.2",
+      "version": "6.0",
       "commands": [
         "dotnet-ef"
       ]

--- a/src/AdminSite/.config/dotnet-tools.json
+++ b/src/AdminSite/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "dotnet-ef": {
-      "version": "6.0",
+      "version": "7.0",
       "commands": [
         "dotnet-ef"
       ]

--- a/src/CustomerSite/.config/dotnet-tools.json
+++ b/src/CustomerSite/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "dotnet-ef": {
-      "version": "3.1.2",
+      "version": "6.0",
       "commands": [
         "dotnet-ef"
       ]

--- a/src/CustomerSite/.config/dotnet-tools.json
+++ b/src/CustomerSite/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "dotnet-ef": {
-      "version": "6.0",
+      "version": "7.0",
       "commands": [
         "dotnet-ef"
       ]


### PR DESCRIPTION
The dotnet-ef is required when you want to 'dotnet tool migrations add Baseline_vX'. Old version causes error, because it installs not compatible version.