### PR TITLE
Fixes for accelerator accessibility issues

### DIFF
--- a/src/AdminSite/Views/ApplicationConfig/ApplicationConfigDetails.cshtml
+++ b/src/AdminSite/Views/ApplicationConfig/ApplicationConfigDetails.cshtml
@@ -27,15 +27,15 @@
                     <td>
                         @if (@Model.Name.Equals("SMTPPassword") && @Model.Value.Length > 5)
                         {
-                            @Html.EditorFor(model => model.Value, new { htmlAttributes = new { type ="password", @class = "form-control" } })
+                            @Html.EditorFor(model => model.Value, new { htmlAttributes = new { type ="password", @class = "form-control", aria_label="Value" } })
                         }
                         else
                         {
-                            @Html.EditorFor(model => model.Value, new { htmlAttributes = new { @class = "form-control" } })
+                            @Html.EditorFor(model => model.Value, new { htmlAttributes = new { @class = "form-control", aria_label="Value" } })
                         }
                     </td>
                     <td>
-                        @Html.EditorFor(model => model.Description,new { htmlAttributes = new { @class = "form-control" } })
+                        @Html.EditorFor(model => model.Description,new { htmlAttributes = new { @class = "form-control", aria_label="Description" } })
                     </td>
                 </tr>
             </tbody>

--- a/src/AdminSite/Views/ApplicationConfig/EmailTemplateDetails.cshtml
+++ b/src/AdminSite/Views/ApplicationConfig/EmailTemplateDetails.cshtml
@@ -22,34 +22,34 @@
             <tbody>
                 <tr>
                     <td class="text-left">IsActive</td>
-                    <td class="text-left">@Html.CheckBoxFor(model => model.IsActive, new { htmlAttributes = new { type ="checkbox", @class = "float-left", name="IsActive" } })</td>
+                    <td class="text-left">@Html.CheckBoxFor(model => model.IsActive, new { htmlAttributes = new { type ="checkbox", @class = "float-left", name="IsActive" }, aria_label="Is active" })</td>
                 </tr>
                 <tr>
                     <td class="text-left">Subject</td>
-                    <td class="text-left">@Html.EditorFor(model => model.Subject, new { htmlAttributes = new {  @class = "form-control", name="Subject" } })</td>
+                    <td class="text-left">@Html.EditorFor(model => model.Subject, new { htmlAttributes = new {  @class = "form-control", name="Subject", aria_label="Subject" } })</td>
                 </tr>
                 <tr>
                     <td class="text-left">Description</td>
-                    <td class="text-left">@Html.EditorFor(model => model.Description, new { htmlAttributes = new { @class = "form-control", name="Description" } })</td>
+                    <td class="text-left">@Html.EditorFor(model => model.Description, new { htmlAttributes = new { @class = "form-control", name="Description", aria_label="Description" } })</td>
                 </tr>
                 <tr>
                     <td class="text-left">TemplateBody</td>
                     <td class="text-left">
-                        @Html.TextAreaFor(model => model.TemplateBody, new { @class = "form-control" })
+                        @Html.TextAreaFor(model => model.TemplateBody, new { @class = "form-control", aria_label="Template Body" })
                         <span class="font-italic hint-text text-left">Due to the content size, it is recommended to copy the content to an external editor, modify the Template body, paste it back into here and save.</span>
                     </td>
                 </tr>
                 <tr>
                     <td class="text-left">ToRecipients</td>
-                    <td class="text-left">@Html.EditorFor(model => model.ToRecipients, new { htmlAttributes = new { @class = "form-control", name="ToRecipients" } })</td>
+                    <td class="text-left">@Html.EditorFor(model => model.ToRecipients, new { htmlAttributes = new { @class = "form-control", name="ToRecipients", aria_label="To Recipients" } })</td>
                 </tr>
                 <tr>
                     <td class="text-left">Bcc</td>
-                    <td class="text-left">@Html.EditorFor(model => model.Bcc, new { htmlAttributes = new { @class = "form-control", name="Bcc" } })</td>
+                    <td class="text-left">@Html.EditorFor(model => model.Bcc, new { htmlAttributes = new { @class = "form-control", name="Bcc", aria_label="Bcc" } })</td>
                 </tr>
                 <tr>
                     <td class="text-left">Cc</td>
-                    <td class="text-left">@Html.EditorFor(model => model.Cc, new { htmlAttributes = new { @class = "form-control", name="Cc" } })</td>
+                    <td class="text-left">@Html.EditorFor(model => model.Cc, new { htmlAttributes = new { @class = "form-control", name="Cc", aria_label="Cc" } })</td>
                 </tr>
             </tbody>
         </table>

--- a/src/AdminSite/Views/ApplicationConfig/EmailTemplates.cshtml
+++ b/src/AdminSite/Views/ApplicationConfig/EmailTemplates.cshtml
@@ -19,7 +19,7 @@
 <div class="container">
    <div class="card-body" style="margin-left:-30px;">
         <div class="text-left">
-            <span class="cm-section-heading">Email Templates</span>
+            <h1 class="cm-section-heading">Email Templates</h1>
         </div>
           <div id="emailTemplatesModal">
                 @if (Model != null && Model.Count() > 0)

--- a/src/AdminSite/Views/ApplicationConfig/Index.cshtml
+++ b/src/AdminSite/Views/ApplicationConfig/Index.cshtml
@@ -45,7 +45,7 @@
                                     </td>
                                     <td class="text-left cm-ellipsis">
                                         <div class="nav-item dropdown">
-                                            <a class="nav-link dropdown cm-link-button" href="#" aria-label="@item.Name more options" id="dropdown@(i)" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><i class="fa fa-bars"></i></a>
+                                            <a class="nav-link dropdown cm-link-button" role="menu" href="#" aria-label="@item.Name more options" id="dropdown@(i)" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><i class="fa fa-bars"></i></a>
                                             <div class="dropdown-menu" aria-labelledby="dropdown@(i)">
                                                 <a class="dropdown-item cm-dropdown-option" data-target="#myModal" onclick="ViewAppConfigdetailsById('@item.Id')">Edit</a>
                                             </div>

--- a/src/AdminSite/Views/ApplicationConfig/Index.cshtml
+++ b/src/AdminSite/Views/ApplicationConfig/Index.cshtml
@@ -45,8 +45,8 @@
                                     </td>
                                     <td class="text-left cm-ellipsis">
                                         <div class="nav-item dropdown">
-                                            <a class="nav-link dropdown cm-link-button" href="#" id="dropdown01" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><i class="fa fa-bars"></i></a>
-                                            <div class="dropdown-menu" aria-labelledby="dropdown01">
+                                            <a class="nav-link dropdown cm-link-button" href="#" aria-label="@item.Name more options" id="dropdown@(i)" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><i class="fa fa-bars"></i></a>
+                                            <div class="dropdown-menu" aria-labelledby="dropdown@(i)">
                                                 <a class="dropdown-item cm-dropdown-option" data-target="#myModal" onclick="ViewAppConfigdetailsById('@item.Id')">Edit</a>
                                             </div>
                                         </div>

--- a/src/AdminSite/Views/ApplicationConfig/Index.cshtml
+++ b/src/AdminSite/Views/ApplicationConfig/Index.cshtml
@@ -76,7 +76,7 @@
                               asp-controller="FileUpload" asp-action="Index">
                             <div class="form-group">
                                 <div class="col-md-10">
-                                    <input type="file" name="files" accept=".ico, .png" multiple />
+                                    <input type="file" name="files" accept=".ico, .png" multiple aria-label="Choose files" />
                                 </div>
                             </div>
                             <div class="form-group">

--- a/src/AdminSite/Views/ApplicationConfig/Index.cshtml
+++ b/src/AdminSite/Views/ApplicationConfig/Index.cshtml
@@ -8,7 +8,7 @@
     <div class="">
         <div class="card-body admin-margin">
             <div class="text-left">
-                <span class="cm-section-heading">Application Config</span>
+                <h1 class="cm-section-heading">Application Config</h1>
             </div>
             <div id="myModal">
                 <div class="table-responsive mt20">

--- a/src/AdminSite/Views/ApplicationLog/Index.cshtml
+++ b/src/AdminSite/Views/ApplicationLog/Index.cshtml
@@ -9,7 +9,7 @@
                 <div class="form-group row">
                     <div class="col-md-12">
                         <div class="text-left">
-                            <span class="cm-section-heading">Manage Application Logs</span>
+                            <h1 class="cm-section-heading">Manage Application Logs</h1>
                         </div>
                     </div>
                 </div>

--- a/src/AdminSite/Views/Home/Index.cshtml
+++ b/src/AdminSite/Views/Home/Index.cshtml
@@ -6,7 +6,7 @@
 
     <div class="card p-3 customcards">
         <div class="text-center">
-            <h4 class="display-4" style="font-size:35px;">Welcome to the SaaS accelerator Admin page</h4>
+            <h2 class="display-4" style="font-size:35px;">Welcome to the SaaS accelerator Admin page</h2>
         </div>
         <div class="text-left">
             <!--<p>This is the publisher solution.</p>-->
@@ -37,7 +37,7 @@
                             </div>
                         </div>
                         <div class="programCardTitleLeft">
-                            <h5>Subscriptions</h5>
+                            <h4 class="display-quicklinks-text">Subscriptions</h4>
                         </div>
 
                         <div class="clear"></div>
@@ -66,7 +66,7 @@
                             </div>
                         </div>
                         <div class="programCardTitleLeft">
-                            <h5>Plans</h5>
+                            <h4 class="display-quicklinks-text">Plans</h4>
                         </div>
 
                         <div class="clear"></div>
@@ -96,7 +96,7 @@
 
                         </div>
                         <div class="programCardTitleLeft">
-                            <h5>Offers</h5>
+                            <h4 class="display-quicklinks-text">Offers</h4>
                         </div>
 
                         <div class="clear"></div>
@@ -123,7 +123,7 @@
 
                         </div>
                         <div class="programCardTitleLeft">
-                            <h5>Scheduler</h5>
+                            <h4 class="display-quicklinks-text">Scheduler</h4>
 
                         </div>
 
@@ -139,7 +139,7 @@
         </li>
         }
         <li id="onedash-menu-homepage4">
-            <a class="programCardLink text-capitalize" asp-area="" asp-controller="KnownUsers" asp-action="Index">Test Test Users</a>
+            <a class="programCardLink text-capitalize" asp-area="" asp-controller="KnownUsers" asp-action="Index">Users</a>
             <div class="programCard">
                 <div class="programCardContentWrapper">
                     <div class="programCardTitle minline">
@@ -151,7 +151,7 @@
                             </div>
                         </div>
                         <div class="programCardTitleLeft">
-                            <h5>Users</h5>
+                            <h4 class="display-quicklinks-text">Users</h4>
                         </div>
 
                         <div class="clear"></div>
@@ -164,7 +164,6 @@
                 </div>
             </div>
         
-        
+        </li>
     </ul>
-
 </div>

--- a/src/AdminSite/Views/Home/RecordUsage.cshtml
+++ b/src/AdminSite/Views/Home/RecordUsage.cshtml
@@ -18,7 +18,7 @@
                 <div class="form-group row">
                     <div class="col-md-12">
                         <div class="text-left">
-                            <span class="cm-section-heading">Manage Subscription Usage</span>
+                            <h1 class="cm-section-heading">Manage Subscription Usage</h1>
                         </div>
                         <form asp-action="ManageSubscriptionUsage" method="post">
                             <div class="row p10">

--- a/src/AdminSite/Views/Home/RecordUsage.cshtml
+++ b/src/AdminSite/Views/Home/RecordUsage.cshtml
@@ -29,13 +29,13 @@
                                     @Html.LabelFor(s => s.Quantity, new { @class = "font-weight-bold" })
                                 </div>
                                 <div class="col-md-2">
-                                    @Html.TextBoxFor(s => s.Quantity, null, new { @class = "form-control", @placeholder = "Quantity", required = "required" })
+                                    @Html.TextBoxFor(s => s.Quantity, null, new { @class = "form-control", @placeholder = "Quantity", required = "required", aria_required="true" })
                                 </div>
                                 <div class="col-md-1 pt-1">
                                     @Html.LabelFor(s => s.DimensionsList, "Dimension", new { @class = "font-weight-bold" })
                                 </div>
                                 <div class="col-md-3">
-                                    @Html.DropDownListFor(s => s.SelectedDimension, Model.DimensionsList, "-- Select Dimension --", new { @class = "form-control", required = "required" })
+                                        @Html.DropDownListFor(s => s.SelectedDimension, Model.DimensionsList, "-- Select Dimension --", new { @class = "form-control", required = "required", aria_required="true" })
                                 </div>
                                 <div class="col-md-2">
                                     <button type="submit" class="cm-button-default mt0">Record Usage</button>

--- a/src/AdminSite/Views/Home/SubscriptionDetails.cshtml
+++ b/src/AdminSite/Views/Home/SubscriptionDetails.cshtml
@@ -9,7 +9,7 @@
 
         <div>
             <div class="text-left mt40">
-                <span class="cm-section-heading">Subscription Details</span>
+                <h1 class="cm-section-heading">Subscription Details</h1>
             </div>
             @if (Model != null && !string.IsNullOrEmpty(Model.ErrorMessage))
             {

--- a/src/AdminSite/Views/Home/SubscriptionLogDetail.cshtml
+++ b/src/AdminSite/Views/Home/SubscriptionLogDetail.cshtml
@@ -3,7 +3,7 @@
 <div class="modal-dialog modal-lg modal-dialog-scrollable">
     <div class="modal-content">
         <div class="modal-header header-bg">
-            <h4><span class="cm-section-heading"> Activity Log</span></h4>
+            <h1 class="cm-section-heading fw500 mb-0"> Activity Log</h1>
             <button type="button" class="close text-right" data-dismiss="modal">&times;</button>
         </div>
         <div class="modal-body">

--- a/src/AdminSite/Views/Home/SubscriptionQuantityDetail.cshtml
+++ b/src/AdminSite/Views/Home/SubscriptionQuantityDetail.cshtml
@@ -3,7 +3,7 @@
     <div class="modal-dialog modal-lg mt200" data-backdrop="static">
         <div class="modal-content">
             <div class="modal-header header-bg">
-                <h4><span class="cm-section-heading">Change Quantity</span></h4>
+                <h1 class="cm-section-heading fw500 mb-0">Change Quantity</h1>
                 <button type="button" class="close text-right" data-dismiss="modal">&times;</button>
             </div>
             <form asp-action="ChangeSubscriptionQuantity" id="frmSubscriptionQuantityDetailAdmin" method="post">

--- a/src/AdminSite/Views/Home/SubscriptionQuantityDetail.cshtml
+++ b/src/AdminSite/Views/Home/SubscriptionQuantityDetail.cshtml
@@ -43,7 +43,7 @@
                             @Html.DisplayName("New Quantity")
                         </dt>
                         <dd class="col-sm-8 pl80">
-                            @Html.TextBoxFor(s => s.Quantity, new { style = "width:100px" })
+                            @Html.TextBoxFor(s => s.Quantity, new { style = "width:100px", aria_label="New quantity" })
                             @Html.HiddenFor(s => s.Id)
                             @Html.HiddenFor(s => s.PlanId)
                             @Html.HiddenFor(s => s.SubscribeId)

--- a/src/AdminSite/Views/Home/Subscriptions.cshtml
+++ b/src/AdminSite/Views/Home/Subscriptions.cshtml
@@ -25,7 +25,7 @@
                     <div class="filter-box">
                         <span>Filter: </span>
                         <input type="text" size="50" id="filterTextBox" placeholder="Enter any text to filter subscriptions" onkeyup="filterSubscriptions()">
-                        <input type="checkbox" class="statusCheckbox" id="SubscribedOnly" onchange="filterSubscriptions()"/> Hide Unsubscribed
+                        <input type="checkbox" class="statusCheckbox" aria-label="Hide unsubscribed" id="SubscribedOnly" onchange="filterSubscriptions()" /> Hide Unsubscribed
                     </div>
                     <div class="table-responsive mt20">
                         @if (Model.Subscriptions.Count() > 0)

--- a/src/AdminSite/Views/Home/Subscriptions.cshtml
+++ b/src/AdminSite/Views/Home/Subscriptions.cshtml
@@ -18,7 +18,7 @@
             <div>
                 <div class="card-body">
                     <div class="text-left">
-                        <span class="cm-section-heading">Subscriptions</span>
+                        <h1 class="cm-section-heading">Subscriptions</h1>
                         <a onclick="if (confirm('Are you sure you want to fetch all subscriptions?')) { fetchAllSubscriptions(); } else { return false;}" class="btn cm-button text-right float-right">Fetch All Subscriptions</a>
                     </div>
                     <hr />

--- a/src/AdminSite/Views/Home/Subscriptions.cshtml
+++ b/src/AdminSite/Views/Home/Subscriptions.cshtml
@@ -72,7 +72,7 @@
                                             <td class="text-left">@subscription.SubscriptionStatus</td>
                                             <td class="text-left cm-ellipsis">
                                                 <div class="nav-item dropdown">
-                                                    <a class="nav-link dropdown cm-link-button" href="#" aria-label="@subscription.Name more options" id="dropdown@(i)" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><i class="fa fa-bars"></i></a>
+                                                    <a class="nav-link dropdown cm-link-button" href="#" role="menu" aria-label="@subscription.Name more options" id="dropdown@(i)" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><i class="fa fa-bars"></i></a>
                                                     <div class="dropdown-menu" aria-labelledby="dropdown@(i)">
                                                         <a class="dropdown-item cm-dropdown-option" asp-controller="Home" asp-action="SubscriptionDetails" asp-route-subscriptionId="@Model.Subscriptions[i].Id">View Details</a>
                                                         @if (subscription.IsMeteringSupported && subscription.SubscriptionStatus == SubscriptionStatusEnumExtension.Subscribed)

--- a/src/AdminSite/Views/Home/Subscriptions.cshtml
+++ b/src/AdminSite/Views/Home/Subscriptions.cshtml
@@ -72,8 +72,8 @@
                                             <td class="text-left">@subscription.SubscriptionStatus</td>
                                             <td class="text-left cm-ellipsis">
                                                 <div class="nav-item dropdown">
-                                                    <a class="nav-link dropdown cm-link-button" href="#" id="dropdown01" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><i class="fa fa-bars"></i></a>
-                                                    <div class="dropdown-menu" aria-labelledby="dropdown01">
+                                                    <a class="nav-link dropdown cm-link-button" href="#" aria-label="@subscription.Name more options" id="dropdown@(i)" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><i class="fa fa-bars"></i></a>
+                                                    <div class="dropdown-menu" aria-labelledby="dropdown@(i)">
                                                         <a class="dropdown-item cm-dropdown-option" asp-controller="Home" asp-action="SubscriptionDetails" asp-route-subscriptionId="@Model.Subscriptions[i].Id">View Details</a>
                                                         @if (subscription.IsMeteringSupported && subscription.SubscriptionStatus == SubscriptionStatusEnumExtension.Subscribed)
                                                         {

--- a/src/AdminSite/Views/Home/ViewSubscriptionDetail.cshtml
+++ b/src/AdminSite/Views/Home/ViewSubscriptionDetail.cshtml
@@ -4,7 +4,7 @@
     <div class="modal-dialog modal-lg mt200" data-backdrop="static">
         <div class="modal-content">
             <div class="modal-header header-bg">
-                <h4><span class="cm-section-heading">Change Plan</span></h4>
+                <h1 class="cm-section-heading fw500 mb-0">Change Plan</h1>
                 <button type="button" class="close text-right" data-dismiss="modal">&times;</button>
             </div>
             <form asp-action="ChangeSubscriptionPlan" id="frmSubscriptionDetail" method="post">

--- a/src/AdminSite/Views/KnownUsers/Index.cshtml
+++ b/src/AdminSite/Views/KnownUsers/Index.cshtml
@@ -35,7 +35,7 @@
                                 </tbody>
                                 <tfoot>
                                     <tr>
-                                        <td><input type="email" id="txtUserEmail" aria-label="User email" required /></td>
+                                        <td><input type="email" id="txtUserEmail" aria-label="User email" aria-required="true" required /></td>
                                         <td><input type="submit" id="btnAdd" class="btn btn-info" value="Add" /></td>
                                     </tr>
                                 </tfoot>

--- a/src/AdminSite/Views/KnownUsers/Index.cshtml
+++ b/src/AdminSite/Views/KnownUsers/Index.cshtml
@@ -35,7 +35,7 @@
                                 </tbody>
                                 <tfoot>
                                     <tr>
-                                        <td><input type="email" id="txtUserEmail" required /></td>
+                                        <td><input type="email" id="txtUserEmail" aria-label="User email" required /></td>
                                         <td><input type="submit" id="btnAdd" class="btn btn-info" value="Add" /></td>
                                     </tr>
                                 </tfoot>

--- a/src/AdminSite/Views/KnownUsers/Index.cshtml
+++ b/src/AdminSite/Views/KnownUsers/Index.cshtml
@@ -10,7 +10,7 @@
     <div class="">
         <div class="card-body">
             <div class="text-left">
-                <span class="cm-section-heading">Users</span>
+                <h1 class="cm-section-heading">Users</h1>
             </div>
             <div id="myModal">
                 <form id="formKnownUsers">

--- a/src/AdminSite/Views/Offers/Index.cshtml
+++ b/src/AdminSite/Views/Offers/Index.cshtml
@@ -31,8 +31,8 @@
                                         </td>
                                         <td class="text-left cm-ellipsis">
                                             <div class="nav-item dropdown">
-                                                <a class="nav-link dropdown cm-link-button" href="#" id="dropdown01" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><i class="fa fa-bars"></i></a>
-                                                <div class="dropdown-menu" aria-labelledby="dropdown01">
+                                                <a class="nav-link dropdown cm-link-button" href="#" aria-label="@item.OfferId more options" id="dropdown@(i)" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><i class="fa fa-bars"></i></a>
+                                                <div class="dropdown-menu" aria-labelledby="dropdown@(i)">
                                                     <a class="dropdown-item cm-dropdown-option" data-target="#myModal" onclick="ViewOfferDetailsById('@item.OfferGuid')">Edit</a>
                                                 </div>
                                             </div>

--- a/src/AdminSite/Views/Offers/Index.cshtml
+++ b/src/AdminSite/Views/Offers/Index.cshtml
@@ -31,7 +31,7 @@
                                         </td>
                                         <td class="text-left cm-ellipsis">
                                             <div class="nav-item dropdown">
-                                                <a class="nav-link dropdown cm-link-button" href="#" aria-label="@item.OfferId more options" id="dropdown@(i)" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><i class="fa fa-bars"></i></a>
+                                                <a class="nav-link dropdown cm-link-button" role="menu" href="#" aria-label="@item.OfferId more options" id="dropdown@(i)" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><i class="fa fa-bars"></i></a>
                                                 <div class="dropdown-menu" aria-labelledby="dropdown@(i)">
                                                     <a class="dropdown-item cm-dropdown-option" data-target="#myModal" onclick="ViewOfferDetailsById('@item.OfferGuid')">Edit</a>
                                                 </div>

--- a/src/AdminSite/Views/Offers/Index.cshtml
+++ b/src/AdminSite/Views/Offers/Index.cshtml
@@ -8,7 +8,7 @@
     <div class="">
         <div class="card-body" style="margin-left:-30px;">
             <div class="text-left">
-                <span class="cm-section-heading">Offers</span>
+                <h1 class="cm-section-heading">Offers</h1>
             </div>
             <div id="myModal">
                 @if (Model != null && Model.Any())

--- a/src/AdminSite/Views/Plans/Index.cshtml
+++ b/src/AdminSite/Views/Plans/Index.cshtml
@@ -41,7 +41,7 @@
                                         </td>
                                         <td class="text-left cm-ellipsis">
                                             <div class="nav-item dropdown">
-                                                <a class="nav-link dropdown cm-link-button" href="#" aria-label="@item.DisplayName more options" id="dropdown@(i)" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><i class="fa fa-bars"></i></a>
+                                                <a class="nav-link dropdown cm-link-button" href="#" role="menu" aria-label="@item.DisplayName more options" id="dropdown@(i)" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><i class="fa fa-bars"></i></a>
                                                 <div class="dropdown-menu" aria-labelledby="dropdown@(i)">
                                                     <a class="dropdown-item cm-dropdown-option" data-target="#myModal" onclick="ViewPlandetailsById('@item.PlanGUID')">Edit</a>
                                                 </div>

--- a/src/AdminSite/Views/Plans/Index.cshtml
+++ b/src/AdminSite/Views/Plans/Index.cshtml
@@ -8,7 +8,7 @@
     <div class="">
         <div class="card-body">
             <div class="text-left">
-                <span class="cm-section-heading">Plans</span>
+                <h1 class="cm-section-heading">Plans</h1>
             </div>
 
             <div id="myModal">

--- a/src/AdminSite/Views/Plans/Index.cshtml
+++ b/src/AdminSite/Views/Plans/Index.cshtml
@@ -41,8 +41,8 @@
                                         </td>
                                         <td class="text-left cm-ellipsis">
                                             <div class="nav-item dropdown">
-                                                <a class="nav-link dropdown cm-link-button" href="#" id="dropdown01" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><i class="fa fa-bars"></i></a>
-                                                <div class="dropdown-menu" aria-labelledby="dropdown01">
+                                                <a class="nav-link dropdown cm-link-button" href="#" aria-label="@item.DisplayName more options" id="dropdown@(i)" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><i class="fa fa-bars"></i></a>
+                                                <div class="dropdown-menu" aria-labelledby="dropdown@(i)">
                                                     <a class="dropdown-item cm-dropdown-option" data-target="#myModal" onclick="ViewPlandetailsById('@item.PlanGUID')">Edit</a>
                                                 </div>
                                             </div>

--- a/src/AdminSite/Views/Plans/PlanDetails.cshtml
+++ b/src/AdminSite/Views/Plans/PlanDetails.cshtml
@@ -61,7 +61,7 @@
                                             </td>
                                             <td>
                                                 @*<input type="checkbox" id="PlanAttributes[@i].IsEnabled" name="OfferAttributes[@i].IsEnabled" value="@Model.PlanAttributes[i].IsEnabled" />*@
-                                                @Html.CheckBoxFor(model => model.PlanAttributes[i].IsEnabled, new { name = "PlanAttributes[@i].IsEnabled", id = string.Format("PlanAttributes_IsEnabled_{0}", @i) })
+                                                @Html.CheckBoxFor(model => model.PlanAttributes[i].IsEnabled, new { name = "PlanAttributes[@i].IsEnabled", id = string.Format("PlanAttributes_IsEnabled_{0}", @i), aria_label=@Model.PlanAttributes[i].DisplayName })
                                             </td>
                                         </tr>
 
@@ -109,18 +109,16 @@
                                                 @Model.PlanEvents[i].EventName
                                             </td>
                                             <td>
-                                                @Html.CheckBoxFor(model => model.PlanEvents[i].Isactive, new { name = "PlanEvents[@i].Isactive", id = string.Format("PlanEvents_Isactive_{0}", @i) })
+                                                @Html.CheckBoxFor(model => model.PlanEvents[i].Isactive, new { name = "PlanEvents[@i].Isactive", id = string.Format("PlanEvents_Isactive_{0}", @i), aria_label=string.Format("{0} active",Model.PlanEvents[i].EventName) })
                                                 @*<input type="checkbox" id="PlanEvents_IsEnabled_@i" name="PlanEvents[@i].IsEnabled" value="@Model.PlanEvents[i].IsEnabled" />*@
                                             </td>
                                             <td>
-                                                @Html.CheckBoxFor(model => model.PlanEvents[i].CopyToCustomer, new { name = "PlanEvents[@i].CopyToCustomer", id = string.Format("PlanEvents_CopyToCustomer_{0}", @i) })
+                                                @Html.CheckBoxFor(model => model.PlanEvents[i].CopyToCustomer, new { name = "PlanEvents[@i].CopyToCustomer", id = string.Format("PlanEvents_CopyToCustomer_{0}", @i), aria_label=string.Format("{0} Copy to customer",Model.PlanEvents[i].EventName) })
                                                 @*<input type="checkbox" id="PlanEvents_IsEnabled_@i" name="PlanEvents[@i].IsEnabled" value="@Model.PlanEvents[i].IsEnabled" />*@
                                             </td>
-                                            <td><input type="text" style="width:200px;" id="PlanEvents_SuccessStateEmails_@i" name="PlanEvents[@i].SuccessStateEmails" value="@Model.PlanEvents[i].SuccessStateEmails" /></td>
-                                            <td><input type="text" style="width:200px;" id="PlanEvents_FailureStateEmails_@i" name="PlanEvents[@i].FailureStateEmails" value="@Model.PlanEvents[i].FailureStateEmails" /></td>
+                                            <td><input type="text" style="width:200px;" id="PlanEvents_SuccessStateEmails_@i" name="PlanEvents[@i].SuccessStateEmails" value="@Model.PlanEvents[i].SuccessStateEmails" aria-label="@Model.PlanEvents[i].EventName Success State Emails" /></td>
+                                            <td><input type="text" style="width:200px;" id="PlanEvents_FailureStateEmails_@i" name="PlanEvents[@i].FailureStateEmails" value="@Model.PlanEvents[i].FailureStateEmails" aria-label="@Model.PlanEvents[i].EventName Failure State Emails" /></td>
                                         </tr>
-
-
                                     }
                                 </tbody>
                             </table>

--- a/src/AdminSite/Views/Scheduler/Index.cshtml
+++ b/src/AdminSite/Views/Scheduler/Index.cshtml
@@ -78,7 +78,7 @@
                                         </td>
                                          <td class="text-left cm-ellipsis">
                                             <div class="nav-item dropdown">
-                                                <a class="nav-link dropdown cm-link-button" href="#" aria-label="@item.SchedulerName more options" id="dropdown@(i)" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><i class="fa fa-bars"></i></a>
+                                            <a class="nav-link dropdown cm-link-button" href="#" role="menu" aria-label="@item.SchedulerName more options" id="dropdown@(i)" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><i class="fa fa-bars"></i></a>
                                                 <div class="dropdown-menu" aria-labelledby="dropdown@(i)">
                                                     <a  class="dropdown-item cm-dropdown-option" href="Scheduler/DeleteSchedulerItem/@item.Id" onclick="return confirm('Are you sure?');" >Delete</a>
                                                     <a  class="dropdown-item cm-dropdown-option" href="Scheduler/SchedulerLogDetail/@item.Id">History</a>

--- a/src/AdminSite/Views/Scheduler/Index.cshtml
+++ b/src/AdminSite/Views/Scheduler/Index.cshtml
@@ -78,8 +78,8 @@
                                         </td>
                                          <td class="text-left cm-ellipsis">
                                             <div class="nav-item dropdown">
-                                                <a class="nav-link dropdown cm-link-button" href="#" id="dropdown01" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><i class="fa fa-bars"></i></a>
-                                                <div class="dropdown-menu" aria-labelledby="dropdown01">
+                                                <a class="nav-link dropdown cm-link-button" href="#" aria-label="@item.SchedulerName more options" id="dropdown@(i)" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><i class="fa fa-bars"></i></a>
+                                                <div class="dropdown-menu" aria-labelledby="dropdown@(i)">
                                                     <a  class="dropdown-item cm-dropdown-option" href="Scheduler/DeleteSchedulerItem/@item.Id" onclick="return confirm('Are you sure?');" >Delete</a>
                                                     <a  class="dropdown-item cm-dropdown-option" href="Scheduler/SchedulerLogDetail/@item.Id">History</a>
                                                 </div>

--- a/src/AdminSite/Views/Scheduler/Index.cshtml
+++ b/src/AdminSite/Views/Scheduler/Index.cshtml
@@ -8,7 +8,7 @@
     <div class="">
         <div class="card-body">
             <div class="text-center">
-                <span class="cm-section-heading">Current Metered Plan Scheduled Trigger</span>
+                <h1 class="cm-section-heading">Current Metered Plan Scheduled Trigger</h1>
                 <button type="submit"  onclick="@("window.location.href='" + @Url.Action("NewScheduler", "Scheduler") + "'");" class="cm-button-default text-right float-right">Add New Scheduled Metered Trigger</button>
             </div>
         </div>

--- a/src/AdminSite/Views/Scheduler/NewScheduler.cshtml
+++ b/src/AdminSite/Views/Scheduler/NewScheduler.cshtml
@@ -55,7 +55,7 @@
         
         <div class="card-body">
             <div class="text-left">
-                <span class="cm-section-heading">Add New Scheduled Trigger for Metered Plan</span>
+                <h1 class="cm-section-heading">Add New Scheduled Trigger for Metered Plan</h1>
             </div>
         </div>
 

--- a/src/AdminSite/Views/Scheduler/NewScheduler.cshtml
+++ b/src/AdminSite/Views/Scheduler/NewScheduler.cshtml
@@ -74,7 +74,7 @@
 
                     <tr>
                         <th>Scheduler Name&nbsp;&nbsp;</th>
-                        <th>@Html.TextBoxFor(s => s.SchedulerName, "",  new { @class = "form-control", required = "required" , pattern = @"^[a-zA-Z0-9-_]+$" })</th>
+                        <th>@Html.TextBoxFor(s => s.SchedulerName, "",  new { @class = "form-control", required = "required" , pattern = @"^[a-zA-Z0-9-_]+$", aria_label="Scheduler name" })</th>
                     </tr>
                     <tr>
                         <th>Subscription</th>
@@ -86,7 +86,7 @@
                     </tr>
                     <tr>
                         <th>Quantity</th>
-                        <th><input asp-for="Quantity" type="number" class="form-control"  step="1" min="1" value="@Model.Quantity" required="true"></th>
+                        <th><input asp-for="Quantity" type="number" class="form-control" step="1" min="1" value="@Model.Quantity" required="true" aria-label="Quantity"></th>
                     </tr>
 
                     <tr>
@@ -96,7 +96,7 @@
                     <tr>
                         <th>First Run Date &nbsp;&nbsp; </th>
                         <th>  
-                            <input asp-for="FirstRunDate" id="FirstRunDate" type="datetime-local" class="form-control"  required="true" size="24">
+                            <input asp-for="FirstRunDate" id="FirstRunDate" type="datetime-local" class="form-control" required="true" size="24" aria-label="First run date">
                         </th>
                          <th>Time will be rounded to nearest Hour</th>
                     </tr>

--- a/src/AdminSite/Views/Scheduler/NewScheduler.cshtml
+++ b/src/AdminSite/Views/Scheduler/NewScheduler.cshtml
@@ -74,29 +74,29 @@
 
                     <tr>
                         <th>Scheduler Name&nbsp;&nbsp;</th>
-                        <th>@Html.TextBoxFor(s => s.SchedulerName, "",  new { @class = "form-control", required = "required" , pattern = @"^[a-zA-Z0-9-_]+$", aria_label="Scheduler name" })</th>
+                        <th>@Html.TextBoxFor(s => s.SchedulerName, "",  new { @class = "form-control", required = "required" , pattern = @"^[a-zA-Z0-9-_]+$", aria_label="Scheduler name", aria_required="true" })</th>
                     </tr>
                     <tr>
                         <th>Subscription</th>
-                        <th>@Html.DropDownListFor(s => s.SelectedSubscription, Model.SubscriptionList, "-- Select Subscription --", new { @class = "form-control", required = "required"})</th>
+                        <th>@Html.DropDownListFor(s => s.SelectedSubscription, Model.SubscriptionList, "-- Select Subscription --", new { @class = "form-control", required = "required", aria_label="Subscription", aria_required="true"})</th>
                     </tr>
                     <tr>
                         <th>Dimension</th>
-                        <th>@Html.DropDownListFor(s => s.SelectedDimension, Model.DimensionsList, "-- Select Dimension --", new { @class = "form-control", required = "required" })</th>
+                        <th>@Html.DropDownListFor(s => s.SelectedDimension, Model.DimensionsList, "-- Select Dimension --", new { @class = "form-control", required = "required", aria_label="Dimension", aria_required="true" })</th>
                     </tr>
                     <tr>
                         <th>Quantity</th>
-                        <th><input asp-for="Quantity" type="number" class="form-control" step="1" min="1" value="@Model.Quantity" required="true" aria-label="Quantity"></th>
+                        <th><input asp-for="Quantity" type="number" class="form-control" step="1" min="1" value="@Model.Quantity" required="true" aria-label="Quantity" aria-required="true"></th>
                     </tr>
 
                     <tr>
                         <th>Frequency</th>
-                       <th>@Html.DropDownListFor(s => s.SelectedSchedulerFrequency, Model.SchedulerFrequencyList, "-- Select Frequency --", new { @class = "form-control", required = "required" })</th>
+                        <th>@Html.DropDownListFor(s => s.SelectedSchedulerFrequency, Model.SchedulerFrequencyList, "-- Select Frequency --", new { @class = "form-control", required = "required", aria_label="Frequency", aria_required="true" })</th>
                     </tr>
                     <tr>
                         <th>First Run Date &nbsp;&nbsp; </th>
                         <th>  
-                            <input asp-for="FirstRunDate" id="FirstRunDate" type="datetime-local" class="form-control" required="true" size="24" aria-label="First run date">
+                            <input asp-for="FirstRunDate" id="FirstRunDate" type="datetime-local" class="form-control" required="true" size="24" aria-label="First run date" aria-required="true">
                         </th>
                          <th>Time will be rounded to nearest Hour</th>
                     </tr>

--- a/src/AdminSite/Views/Scheduler/SchedulerLogDetail.cshtml
+++ b/src/AdminSite/Views/Scheduler/SchedulerLogDetail.cshtml
@@ -36,7 +36,7 @@
 
     <div class="card-body">
         <div class="modal-header header-bg">
-            <h1><span class="cm-section-heading"> Activity Log</span></h1>
+            <h1 class="cm-section-heading"> Activity Log</h1>
             <button type="submit"onclick="@("window.location.href='" + @Url.Action("index", "Scheduler") + "'");" class="cm-button-default text-right float-right">Back To Scheduler List</button>
         </div>
         <div class="modal-body">

--- a/src/AdminSite/Views/Shared/_CookieConsentPartial.cshtml
+++ b/src/AdminSite/Views/Shared/_CookieConsentPartial.cshtml
@@ -10,7 +10,7 @@
 {
     <div id="cookieConsent" class="alert alert-info alert-dismissible fade show" role="alert">
         The application uses cookies to give you a better experience. By proceeding to access the application, you agree to our use of cookies.
-        <button type="button" class="accept-policy close" data-dismiss="alert" aria-label="Close" data-cookie-string="@cookieString">
+        <button type="button" class="accept-policy close" data-dismiss="alert" aria-label="Ok" data-cookie-string="@cookieString">
             <span aria-hidden="true">OK</span>
         </button>
     </div>

--- a/src/AdminSite/Views/Shared/_Layout.cshtml
+++ b/src/AdminSite/Views/Shared/_Layout.cshtml
@@ -21,7 +21,7 @@
 <body style="padding-top: 0px;">
     <nav class="navbar navbar-expand-lg fixed-top navbar-dark cm-top-nav-bar">
         <a class="navbar-brand mr-auto mr-lg-0" href="@Url.Action("Index", "Home")">
-            <img class="cm-logo pull-left" src="~/contoso-sales.png" />
+            <img class="cm-logo pull-left" alt="logo" src="~/contoso-sales.png" />
             @*<img class="cm-logo pull-left" src="https://kblnuser.azurewebsites.net/logo.png" />*@
         </a>
         @*<a class="navbar-brand mr-auto mr-lg-0" asp-area="" asp-controller="Home" asp-action="Index">SaasWeb Demo</a>*@
@@ -35,11 +35,11 @@
                 @if (this.User.Identity.IsAuthenticated)
                 {
                     <span class="cm-username text-white">@User.Identity.Name&nbsp;</span>
-                    <a class="text-white cm-logout" asp-controller="Account" asp-action="SignOut">&nbsp;<i class="fa fa-sign-out fa-2x"></i></a>
+                    <a class="text-white cm-logout" aria-label="Sign out" asp-controller="Account" asp-action="SignOut">&nbsp;<i class="fa fa-sign-out fa-2x"></i></a>
                 }
                 else
                 {
-                    <a class="text-white" asp-controller="Account" asp-action="SignIn">Sign in</a>
+                    <a class="text-white" aria-label="Sign in" asp-controller="Account" asp-action="SignIn">Sign in</a>
                 }
             </div>
         </div>
@@ -47,7 +47,7 @@
     <div class="mycontainer" style="height:auto; min-height: 100vh; padding-top: 55px">
         <div class="class1">
             <div>
-                <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarCollapse" aria-controls="navbarCollapse" aria-expanded="true" color="#c2c2c2" aria-label="Toggle navigation">
+                <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="[name='navbarCollapse']" aria-expanded="true" color="#c2c2c2" aria-label="Toggle navigation">
                     <svg xmlns="http://www.w3.org/2000/svg" x="0px" y="0px"
                          width="24" height="24"
                          viewBox="0 0 172 172"
@@ -64,7 +64,7 @@
                             <ul class="navbar-nav mr-auto">
                                 <li class="container-fluid nav-item nav-link minline">
                                     <div class=" minline">
-                                        <a class="nav-link" asp-area="" asp-controller="Home" asp-action="Index">
+                                        <a class="nav-link" aria-label="Home" asp-area="" asp-controller="Home" asp-action="Index">
                                             <svg xmlns="http://www.w3.org/2000/svg" x="0px" y="0px"
                                                  width="25" height="25"
                                                  viewBox="0 0 172 172"
@@ -73,12 +73,12 @@
                                             </svg>
                                         </a>
                                     </div>
-                                    <div class="minline"><a class="nav-link collapse navbar-collapse navbar-text" id="navbarCollapse" asp-area="" asp-controller="Home" asp-action="Index">Home</a></div>
+                                    <div class="minline"><a class="nav-link collapse navbar-collapse navbar-text" aria-label="Home" name="navbarCollapse" asp-area="" asp-controller="Home" asp-action="Index">Home</a></div>
 
                                 </li>
                                 <li class="container nav-item nav-link minline">
                                     <div class="minline">
-                                        <a class="nav-link" asp-area="" asp-controller="Home" asp-action="Subscriptions">
+                                        <a class="nav-link" aria-label="Subscriptions" asp-area="" asp-controller="Home" asp-action="Subscriptions">
                                             <svg xmlns="http://www.w3.org/2000/svg" x="0px" y="0px"
                                                  width="25" height="25"
                                                  viewBox="0 0 172 172"
@@ -88,12 +88,12 @@
                                         </a>
                                     </div>
 
-                                    <div class="minline"><a class="nav-link collapse navbar-collapse navbar-text" id="navbarCollapse" asp-area="" asp-controller="Home" asp-action="Subscriptions">Subscriptions</a></div>
+                                    <div class="minline"><a class="nav-link collapse navbar-collapse navbar-text" name="navbarCollapse" aria-label="Subscriptions" asp-area="" asp-controller="Home" asp-action="Subscriptions">Subscriptions</a></div>
 
                                 </li>
                                 <li class="nav-item nav-link minline">
                                     <div class="minline">
-                                        <a class="nav-link" asp-area="" asp-controller="Plans" asp-action="Index">
+                                        <a class="nav-link" aria-label="Plans" asp-area="" asp-controller="Plans" asp-action="Index">
                                             <svg xmlns="http://www.w3.org/2000/svg" x="0px" y="0px"
                                                  width="25" height="25"
                                                  viewBox="0 0 172 172"
@@ -102,12 +102,12 @@
                                             </svg>
                                         </a>
                                     </div>
-                                    <div class="minline"><a class="left-nav nav-link collapse navbar-collapse navbar-text" id="navbarCollapse" asp-area="" asp-controller="Plans" asp-action="Index">Plans</a></div>
+                                    <div class="minline"><a class="left-nav nav-link collapse navbar-collapse navbar-text" name="navbarCollapse" aria-label="Plans" asp-area="" asp-controller="Plans" asp-action="Index">Plans</a></div>
 
                                 </li>
                                 <li class="nav-item nav-link minline">
                                     <div class="minline">
-                                        <a class="nav-link" asp-area="" asp-controller="Offers" asp-action="Index">
+                                        <a class="nav-link" aria-label="Offers" asp-area="" asp-controller="Offers" asp-action="Index">
                                             <svg xmlns="http://www.w3.org/2000/svg" x="0px" y="0px"
                                                  width="25" height="25"
                                                  viewBox="0 0 172 172"
@@ -116,46 +116,47 @@
                                             </svg>
                                         </a>
                                     </div>
-                                    <div class="minline"><a class="left-nav nav-link collapse navbar-collapse navbar-text" id="navbarCollapse" asp-area="" asp-controller="Offers" asp-action="Index">Offers</a></div>
+                                    <div class="minline"><a class="left-nav nav-link collapse navbar-collapse navbar-text" name="navbarCollapse" aria-label="Offers" asp-area="" asp-controller="Offers" asp-action="Index">Offers</a></div>
                                 </li>
 
                                 @if (this.Context.Session.GetString("SupportMeteredBilling") != null)
                                 {
                                     <li class="nav-item nav-link minline">
                                         <div class="minline">
-                                            <a class="nav-link" asp-area="" asp-controller="Scheduler" asp-action="Index">
+                                            <a class="nav-link" aria-label="Scheduler" asp-area="" asp-controller="Scheduler" asp-action="Index">
                                                 <svg xmlns="http://www.w3.org/2000/svg" width="25" height="25" fill="currentColor" class="bi bi-stopwatch-fill" viewBox="0 0 16 16">
                                                   <path d="M6.5 0a.5.5 0 0 0 0 1H7v1.07A7.001 7.001 0 0 0 8 16a7 7 0 0 0 5.29-11.584.531.531 0 0 0 .013-.012l.354-.354.353.354a.5.5 0 1 0 .707-.707l-1.414-1.415a.5.5 0 1 0-.707.707l.354.354-.354.354a.717.717 0 0 0-.012.012A6.973 6.973 0 0 0 9 2.071V1h.5a.5.5 0 0 0 0-1h-3zm2 5.6V9a.5.5 0 0 1-.5.5H4.5a.5.5 0 0 1 0-1h3V5.6a.5.5 0 1 1 1 0z"/>
                                                 </svg>
                                            </a>
                                         </div>
-                                        <div class="minline"><a class="left-nav nav-link collapse navbar-collapse navbar-text" id="navbarCollapse" asp-area="" asp-controller="Scheduler" asp-action="Index">Scheduler</a></div>
+                                        <div class="minline"><a class="left-nav nav-link collapse navbar-collapse navbar-text" name="navbarCollapse" aria-label="Scheduler" asp-area="" asp-controller="Scheduler" asp-action="Index">Scheduler</a></div>
                                     </li>
                                 }
 
                                 <li class="nav-item nav-link minline">
                                     <div class="minline">
-                                        <a class="nav-link" asp-area="" asp-controller="KnownUsers" asp-action="Index">
+                                        <a class="nav-link" aria-label="Users" asp-area="" asp-controller="KnownUsers" asp-action="Index">
                                             <svg xmlns="http://www.w3.org/2000/svg" width="25" height="25" fill="#c2c2c2" class="bi bi-people" viewBox="0 0 16 16">
                                                 <path d="M15 14s1 0 1-1-1-4-5-4-5 3-5 4 1 1 1 1h8zm-7.978-1A.261.261 0 0 1 7 12.996c.001-.264.167-1.03.76-1.72C8.312 10.629 9.282 10 11 10c1.717 0 2.687.63 3.24 1.276.593.69.758 1.457.76 1.72l-.008.002a.274.274 0 0 1-.014.002H7.022zM11 7a2 2 0 1 0 0-4 2 2 0 0 0 0 4zm3-2a3 3 0 1 1-6 0 3 3 0 0 1 6 0zM6.936 9.28a5.88 5.88 0 0 0-1.23-.247A7.35 7.35 0 0 0 5 9c-4 0-5 3-5 4 0 .667.333 1 1 1h4.216A2.238 2.238 0 0 1 5 13c0-1.01.377-2.042 1.09-2.904.243-.294.526-.569.846-.816zM4.92 10A5.493 5.493 0 0 0 4 13H1c0-.26.164-1.03.76-1.724.545-.636 1.492-1.256 3.16-1.275zM1.5 5.5a3 3 0 1 1 6 0 3 3 0 0 1-6 0zm3-2a2 2 0 1 0 0 4 2 2 0 0 0 0-4z" />
                                             </svg>
                                         </a>
                                     </div>
                                     <div class="minline">
-                                        <a class="left-nav nav-link collapse navbar-collapse navbar-text" id="navbarCollapse" asp-area="" asp-controller="KnownUsers" asp-action="Index">Users</a>
+                                        <a class="left-nav nav-link collapse navbar-collapse navbar-text" name="navbarCollapse" aria-label="Users" asp-area="" asp-controller="KnownUsers" asp-action="Index">Users</a>
                                     </div>
                                 </li>
 
                                 <li class="nav-item nav-link minline">
                                     <div class="minline">
-                                        <a class="nav-link" asp-area="" asp-controller="ApplicationConfig" asp-action="Index">
+                                        <a class="nav-link" aria-label="Settings" asp-area="" asp-controller="ApplicationConfig" asp-action="Index">
                                             <svg xmlns="http://www.w3.org/2000/svg" width="25" height="25" fill="#c2c2c2" class="bi bi-gear" viewBox="0 0 16 16">
                                             <path d="M8 4.754a3.246 3.246 0 1 0 0 6.492 3.246 3.246 0 0 0 0-6.492zM5.754 8a2.246 2.246 0 1 1 4.492 0 2.246 2.246 0 0 1-4.492 0z"/>
                                             <path d="M9.796 1.343c-.527-1.79-3.065-1.79-3.592 0l-.094.319a.873.873 0 0 1-1.255.52l-.292-.16c-1.64-.892-3.433.902-2.54 2.541l.159.292a.873.873 0 0 1-.52 1.255l-.319.094c-1.79.527-1.79 3.065 0 3.592l.319.094a.873.873 0 0 1 .52 1.255l-.16.292c-.892 1.64.901 3.434 2.541 2.54l.292-.159a.873.873 0 0 1 1.255.52l.094.319c.527 1.79 3.065 1.79 3.592 0l.094-.319a.873.873 0 0 1 1.255-.52l.292.16c1.64.893 3.434-.902 2.54-2.541l-.159-.292a.873.873 0 0 1 .52-1.255l.319-.094c1.79-.527 1.79-3.065 0-3.592l-.319-.094a.873.873 0 0 1-.52-1.255l.16-.292c.893-1.64-.902-3.433-2.541-2.54l-.292.159a.873.873 0 0 1-1.255-.52l-.094-.319zm-2.633.283c.246-.835 1.428-.835 1.674 0l.094.319a1.873 1.873 0 0 0 2.693 1.115l.291-.16c.764-.415 1.6.42 1.184 1.185l-.159.292a1.873 1.873 0 0 0 1.116 2.692l.318.094c.835.246.835 1.428 0 1.674l-.319.094a1.873 1.873 0 0 0-1.115 2.693l.16.291c.415.764-.42 1.6-1.185 1.184l-.291-.159a1.873 1.873 0 0 0-2.693 1.116l-.094.318c-.246.835-1.428.835-1.674 0l-.094-.319a1.873 1.873 0 0 0-2.692-1.115l-.292.16c-.764.415-1.6-.42-1.184-1.185l.159-.291A1.873 1.873 0 0 0 1.945 8.93l-.319-.094c-.835-.246-.835-1.428 0-1.674l.319-.094A1.873 1.873 0 0 0 3.06 4.377l-.16-.292c-.415-.764.42-1.6 1.185-1.184l.292.159a1.873 1.873 0 0 0 2.692-1.115l.094-.319z"/>
                                             </svg>
                                         </a>
                                     </div>
-                                    <div class="minline"><a class="left-nav nav-link collapse navbar-collapse navbar-text" id="navbarCollapse" asp-area="" asp-controller="ApplicationConfig" asp-action="Index">Settings</a>
+                                    <div class="minline">
+                                        <a class="left-nav nav-link collapse navbar-collapse navbar-text" name="navbarCollapse" aria-label="Settings" asp-area="" asp-controller="ApplicationConfig" asp-action="Index">Settings</a>
                                     </div>
                                 </li>
                             </ul>

--- a/src/AdminSite/wwwroot/css/admin-custom.css
+++ b/src/AdminSite/wwwroot/css/admin-custom.css
@@ -78,15 +78,12 @@
 
 .cm-section-heading {
     font-family: Segoe UI,Segoe UI Web,Segoe UI Symbol,Helvetica Neue,BBAlpha Sans,S60 Sans,Arial,sans-serif;
-    /*font-family: 'Segoe UI', 'sans-serif' !important;*/
     font-size: 30px;
     font-weight: 600;
-    /*background-color: #fff;*/
-    /*border-bottom: 4px solid #2180a6;*/
-    /*text-transform: uppercase;*/
     margin-bottom: 20px;
     line-height: 40px;
     color: black;
+    display: inline;
 }
 
 .p10 {
@@ -127,6 +124,10 @@
 
 .mt0 {
     margin-top: 0px !important;
+}
+
+.fw500 {
+    font-weight: 500;
 }
 
 .filter-box {

--- a/src/AdminSite/wwwroot/css/admin-custom.css
+++ b/src/AdminSite/wwwroot/css/admin-custom.css
@@ -505,9 +505,46 @@ button.navbar-toggler:focus, button.navbar-toggler:hover {
     font-weight: bold;
 }
 
-    .close:hover,
-    .close:focus {
-        color: black;
-        text-decoration: none;
-        cursor: pointer;
+.close:hover,
+.close:focus {
+    color: black;
+    text-decoration: none;
+    cursor: pointer;
+}
+
+@media screen and (prefers-color-scheme: light) {
+    .swal-button-container {
+        border: 1px solid;
     }
+
+    .swal-modal {
+        border: 1px solid;
+    }
+
+    .swal-icon--warning__body, .swal-icon--warning__dot {
+        border: 1px solid !important;
+    }
+    .swal-icon--success__line--long, .swal-icon--success__line--tip {
+        border: 1px solid !important;
+    }
+}
+
+@media screen and (prefers-color-scheme: dark) {
+    .swal-button-container {
+        border: 1px solid;
+    }
+
+    .swal-modal {
+        border: 1px solid;
+    }
+
+    .swal-icon--warning__body, .swal-icon--warning__dot {
+        border: 1px solid !important;
+    }
+
+    .swal-icon--success__line--long, .swal-icon--success__line--tip {
+        border: 1px solid !important;
+    }
+}
+
+

--- a/src/CustomerSite/Views/Home/SubscriptionDetail.cshtml
+++ b/src/CustomerSite/Views/Home/SubscriptionDetail.cshtml
@@ -4,7 +4,7 @@
     <div class="modal-dialog modal-lg mt200" data-backdrop="static">
         <div class="modal-content">
             <div class="modal-header header-bg">
-                <h4><span class="cm-section-heading">Change Plan</span></h4>
+                <h1 class="cm-section-heading fw500 mb-0">Change Plan</h1>
                 <button type="button" class="close text-right" data-dismiss="modal">&times;</button>
             </div>
             <form asp-action="ChangeSubscriptionPlan" id="frmSubscriptionDetail" method="post">

--- a/src/CustomerSite/Views/Home/SubscriptionLogDetail.cshtml
+++ b/src/CustomerSite/Views/Home/SubscriptionLogDetail.cshtml
@@ -3,7 +3,7 @@
 <div class="modal-dialog modal-lg modal-dialog-scrollable">
     <div class="modal-content">
         <div class="modal-header header-bg">
-            <h4><span class="cm-section-heading"> Activity Log</span></h4>
+            <h1 class="cm-section-heading fw500 mb-0"> Activity Log</h1>
             <button type="button" class="close text-right" data-dismiss="modal">&times;</button>
         </div>
         <div class="modal-body">

--- a/src/CustomerSite/Views/Home/SubscriptionQuantityDetail.cshtml
+++ b/src/CustomerSite/Views/Home/SubscriptionQuantityDetail.cshtml
@@ -3,7 +3,7 @@
     <div class="modal-dialog modal-lg mt200" data-backdrop="static">
         <div class="modal-content">
             <div class="modal-header header-bg">
-                <h4><span class="cm-section-heading">Change Quantity</span></h4>
+                <h1 class="cm-section-heading fw500 mb-0">Change Quantity</h1>
                 <button type="button" class="close text-right" data-dismiss="modal">&times;</button>
             </div>
             <form asp-action="ChangeSubscriptionQuantity" id="frmSubscriptionQuantityDetail" method="post">

--- a/src/CustomerSite/Views/Home/Subscriptions.cshtml
+++ b/src/CustomerSite/Views/Home/Subscriptions.cshtml
@@ -18,7 +18,7 @@
                 <div class="card-body">
                     <div>
                         <div class="text-left">
-                            <span class="cm-section-heading">Subscriptions</span>
+                            <h1 class="cm-section-heading">Subscriptions</h1>
                         </div>
                         @if (Model.Subscriptions.Count() > 0)
                         {

--- a/src/CustomerSite/Views/Home/Subscriptions.cshtml
+++ b/src/CustomerSite/Views/Home/Subscriptions.cshtml
@@ -56,7 +56,7 @@
                                             <td class="text-left">@subscription.SubscriptionStatus</td>
                                             <td class="text-left  cm-ellipsis">
                                                 <div class="nav-item dropdown">
-                                                    <a class="nav-link dropdown cm-link-button" href="#" aria-label="@subscription.Name more options" id="dropdown@(i)" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><i class="fa fa-bars"></i></a>
+                                                    <a class="nav-link dropdown cm-link-button" href="#" role="menu" aria-label="@subscription.Name more options" id="dropdown@(i)" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><i class="fa fa-bars"></i></a>
                                                     <div class="dropdown-menu" aria-labelledby="dropdown@(i)">
                                                         @if (subscription.SubscriptionStatus == SubscriptionStatusEnumExtension.Subscribed)
                                                         {

--- a/src/CustomerSite/Views/Home/Subscriptions.cshtml
+++ b/src/CustomerSite/Views/Home/Subscriptions.cshtml
@@ -56,8 +56,8 @@
                                             <td class="text-left">@subscription.SubscriptionStatus</td>
                                             <td class="text-left  cm-ellipsis">
                                                 <div class="nav-item dropdown">
-                                                    <a class="nav-link dropdown cm-link-button" href="#" id="dropdown01" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><i class="fa fa-bars"></i></a>
-                                                    <div class="dropdown-menu" aria-labelledby="dropdown01">
+                                                    <a class="nav-link dropdown cm-link-button" href="#" aria-label="@subscription.Name more options" id="dropdown@(i)" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><i class="fa fa-bars"></i></a>
+                                                    <div class="dropdown-menu" aria-labelledby="dropdown@(i)">
                                                         @if (subscription.SubscriptionStatus == SubscriptionStatusEnumExtension.Subscribed)
                                                         {
                                                             <a class="dropdown-item cm-dropdown-option" asp-action="ViewSubscription" asp-route-subscriptionId="@Model.Subscriptions[i].Id" asp-route-planId="@Model.Subscriptions[i].PlanId" asp-route-operation="Deactivate">Unsubscribe</a>

--- a/src/CustomerSite/Views/Home/_LandingPage.cshtml
+++ b/src/CustomerSite/Views/Home/_LandingPage.cshtml
@@ -211,7 +211,7 @@ else
                 <p>
                     Get started with integrating your <b> Software as a Service (SaaS) </b> solution with the <b> SaaS fulfillment APIs version 2 in Microsoft commercial marketplace. </b>
                 </p>
-                <p><a href="https://docs.microsoft.com/en-us/azure/marketplace/partner-center-portal/pc-saas-fulfillment-api-v2" target="_blank">Click here </a><span>for the API documentation.</span> </p>
+                <p><a href="https://docs.microsoft.com/en-us/azure/marketplace/partner-center-portal/pc-saas-fulfillment-api-v2" target="_blank" aria-label="Click here">Click here </a><span>for the API documentation.</span> </p>
             </div>
             <div>
                 <b>To purchase this SaaS offer:</b>

--- a/src/CustomerSite/Views/Home/_LandingPage.cshtml
+++ b/src/CustomerSite/Views/Home/_LandingPage.cshtml
@@ -12,7 +12,7 @@
         <form method="post" id="frmIndex">
 
             <div class="text-white mt20">
-                <span class="cm-section-heading">Subscription Details</span>
+                <h1 class="cm-section-heading">Subscription Details</h1>
             </div>
             @if (Model != null && !string.IsNullOrEmpty(Model.ErrorMessage))
             {

--- a/src/CustomerSite/Views/Home/_LandingPage.cshtml
+++ b/src/CustomerSite/Views/Home/_LandingPage.cshtml
@@ -122,12 +122,12 @@
 
                                             @if (Model.SubscriptionParameters[i].IsRequired == true)
                                             {
-                                                @Html.DropDownList(string.Format("SubscriptionParameters[{0}].Value", @i), selectList, new { @class = @Model.SubscriptionParameters[i].Type + " w200", @required = "required", name = string.Format("SubscriptionParameters[{0}].Value", @i), @id = string.Format("SubscriptionParameters_{0}__Value", @i) })
+                                                @Html.DropDownList(string.Format("SubscriptionParameters[{0}].Value", @i), selectList, new { @class = @Model.SubscriptionParameters[i].Type + " w200", @required = "required", name = string.Format("SubscriptionParameters[{0}].Value", @i), @id = string.Format("SubscriptionParameters_{0}__Value", @i), aria_label=string.Format("{0} Value", @Model.SubscriptionParameters[i].DisplayName) })
 
                                             }
                                             else
                                             {
-                                                @Html.DropDownList(string.Format("SubscriptionParameters[{0}].Value", @i), selectList, new { @class = @Model.SubscriptionParameters[i].Type + " w200", name = string.Format("SubscriptionParameters[{0}].Value", @i), @id = string.Format("SubscriptionParameters_{0}__Value", @i) })
+                                                @Html.DropDownList(string.Format("SubscriptionParameters[{0}].Value", @i), selectList, new { @class = @Model.SubscriptionParameters[i].Type + " w200", name = string.Format("SubscriptionParameters[{0}].Value", @i), @id = string.Format("SubscriptionParameters_{0}__Value", @i), aria_label=string.Format("{0} Value", @Model.SubscriptionParameters[i].DisplayName) })
 
                                             }
 
@@ -140,11 +140,11 @@
 
                                             @if (Model.SubscriptionParameters[i].IsRequired == true)
                                             {
-                                                @Html.TextBoxFor(model => model.SubscriptionParameters[i].Value, new { @class = @Model.SubscriptionParameters[i].Type + " w200", @required = "required", @type = @Model.SubscriptionParameters[i].Htmltype })
+                                                @Html.TextBoxFor(model => model.SubscriptionParameters[i].Value, new { @class = @Model.SubscriptionParameters[i].Type + " w200", @required = "required", @type = @Model.SubscriptionParameters[i].Htmltype, aria_label=string.Format("{0} Value", @Model.SubscriptionParameters[i].DisplayName) })
                                             }
                                             else
                                             {
-                                                @Html.TextBoxFor(model => model.SubscriptionParameters[i].Value, new { @class = @Model.SubscriptionParameters[i].Type + " w200", @type = @Model.SubscriptionParameters[i].Htmltype })
+                                                @Html.TextBoxFor(model => model.SubscriptionParameters[i].Value, new { @class = @Model.SubscriptionParameters[i].Type + " w200", @type = @Model.SubscriptionParameters[i].Htmltype, aria_label=string.Format("{0} Value", @Model.SubscriptionParameters[i].DisplayName) })
                                             }
 
                                         </dd>
@@ -155,11 +155,11 @@
 
                                             @if (Model.SubscriptionParameters[i].IsRequired == true)
                                             {
-                                                @Html.TextBoxFor(model => model.SubscriptionParameters[i].Value, new { @class = @Model.SubscriptionParameters[i].Type + " w200", @required = "required", @type = @Model.SubscriptionParameters[i].Htmltype })
+                                                @Html.TextBoxFor(model => model.SubscriptionParameters[i].Value, new { @class = @Model.SubscriptionParameters[i].Type + " w200", @required = "required", @type = @Model.SubscriptionParameters[i].Htmltype, aria_label=string.Format("{0} Value", @Model.SubscriptionParameters[i].DisplayName) })
                                             }
                                             else
                                             {
-                                                @Html.TextBoxFor(model => model.SubscriptionParameters[i].Value, new { @class = @Model.SubscriptionParameters[i].Type + " w200", @type = @Model.SubscriptionParameters[i].Htmltype })
+                                                @Html.TextBoxFor(model => model.SubscriptionParameters[i].Value, new { @class = @Model.SubscriptionParameters[i].Type + " w200", @type = @Model.SubscriptionParameters[i].Htmltype, aria_label=string.Format("{0} Value", @Model.SubscriptionParameters[i].DisplayName) })
                                             }
 
                                         </dd>

--- a/src/CustomerSite/Views/Shared/_CookieConsentPartial.cshtml
+++ b/src/CustomerSite/Views/Shared/_CookieConsentPartial.cshtml
@@ -10,7 +10,7 @@
 {
     <div id="cookieConsent" class="alert alert-info alert-dismissible fade show" role="alert">
         The application uses cookies to give you a better experience. By proceeding to access the application, you agree to our use of cookies.
-        <button type="button" class="accept-policy close" data-dismiss="alert" aria-label="Close" data-cookie-string="@cookieString">
+        <button type="button" class="accept-policy close" data-dismiss="alert" aria-label="Ok" data-cookie-string="@cookieString">
             <span aria-hidden="true">OK</span>
         </button>
     </div>

--- a/src/CustomerSite/Views/Shared/_Layout.cshtml
+++ b/src/CustomerSite/Views/Shared/_Layout.cshtml
@@ -20,7 +20,7 @@
 <body>
     <nav class="navbar navbar-expand-lg fixed-top navbar-dark cm-top-nav-bar">
         <a class="navbar-brand mr-auto mr-lg-0" href="@Url.Action("Index", "Home")">
-            <img class="cm-logo pull-left" src="~/contoso-sales.png" />
+            <img class="cm-logo pull-left" alt="logo" src="~/contoso-sales.png" />
             @*<img class="cm-logo pull-left" src="https://kblnuser.azurewebsites.net/logo.png" />*@
         </a>
         @*<a class="navbar-brand mr-auto mr-lg-0" asp-area="" asp-controller="Home" asp-action="Index">SaasKit Demo</a>*@
@@ -34,11 +34,11 @@
                 @if (this.User.Identity.IsAuthenticated)
                 {
                     <span class="cm-username text-white">@User.Identity.Name&nbsp;</span>
-                    <a class="text-white cm-logout" asp-controller="Account" asp-action="SignOut">&nbsp;<i class="fa fa-sign-out fa-2x"></i></a>
+                    <a class="text-white cm-logout" aria-label="Sign out" asp-controller=" Account" asp-action="SignOut">&nbsp;<i class="fa fa-sign-out fa-2x"></i></a>
                 }
                 else
                 {
-                    <a class="text-white" asp-controller="Account" asp-action="SignIn">Sign in</a>
+                    <a class="text-white" aria-label="Sign in" asp-controller="Account" asp-action="SignIn">Sign in</a>
                 }
             </div>
         </div>
@@ -48,10 +48,10 @@
             <a class="nav-link active">
                 @if (this.User.Identity.IsAuthenticated)
                 {
-                    <a class="nav-link" asp-area="" asp-controller="Home" asp-action="Index">Home</a>
+                    <a class="nav-link" aria-label="Home" asp-area="" asp-controller="Home" asp-action="Index">Home</a>
                     @if (TempData["ShowWelcomeScreen"] != null && Convert.ToString(TempData["ShowWelcomeScreen"]) == "True")
                     {
-                        <a class="nav-link" asp-area="" asp-controller="Home" asp-action="Subscriptions">Subscriptions</a>
+                        <a class="nav-link" aria-label="Subscriptions" asp-area="" asp-controller="Home" asp-action="Subscriptions">Subscriptions</a>
                     }
                 }
             </a>

--- a/src/CustomerSite/wwwroot/css/customer-custom.css
+++ b/src/CustomerSite/wwwroot/css/customer-custom.css
@@ -86,6 +86,9 @@
     margin-bottom: 20px;
     line-height: 40px;
     color: black;
+    width: fit-content;
+    font-weight: 400;
+    display: inline;
 }
 
 .p10 {
@@ -122,6 +125,10 @@
 
 .mt40 {
     margin-top: 40px;
+}
+
+.fw500 {
+    font-weight: 500;
 }
 
 .cm-button-default {
@@ -357,6 +364,43 @@ a.cm-dropdown-option {
 .mr420 {
     margin-right: !important;
 }
+
 .red-star {
     color: red;
+}
+
+@media screen and (prefers-color-scheme: light) {
+    .swal-button-container {
+        border: 1px solid;
+    }
+
+    .swal-modal {
+        border: 1px solid;
+    }
+
+    .swal-icon--warning__body, .swal-icon--warning__dot {
+        border: 1px solid !important;
+    }
+
+    .swal-icon--success__line--long, .swal-icon--success__line--tip {
+        border: 1px solid !important;
+    }
+}
+
+@media screen and (prefers-color-scheme: dark) {
+    .swal-button-container {
+        border: 1px solid;
+    }
+
+    .swal-modal {
+        border: 1px solid;
+    }
+
+    .swal-icon--warning__body, .swal-icon--warning__dot {
+        border: 1px solid !important;
+    }
+
+    .swal-icon--success__line--long, .swal-icon--success__line--tip {
+        border: 1px solid !important;
+    }
 }

--- a/src/UI.Test/AdminApplicationShould.cs
+++ b/src/UI.Test/AdminApplicationShould.cs
@@ -124,7 +124,7 @@ public class AdminApplicationShould
         gotoSubscriptionsPageFromTile();
 
         //Act
-        driver.FindElement(By.XPath("//span[@class='cm-section-heading']/following-sibling::a")).Click();
+        driver.FindElement(By.XPath("//h1[@class='cm-section-heading']/following-sibling::a")).Click();
 
         //Click OK for Javascript confirm on Fetch Click
         IAlert alert = driver.SwitchTo().Alert();


### PR DESCRIPTION
Fixed below accessibility issues:

- Ensures links have discernible text.
<img width="2968" alt="Note 1 - Ensures links have discernible text" src="https://github.com/Azure/Commercial-Marketplace-SaaS-Accelerator/assets/132065894/f2f2fe2d-2df9-416a-86b1-1a8c7ad7cdce">

- Ensures image elements have alternate text or a role of none or presentation
<img width="1815" alt="Note_1_Ensures img elements have alternate text or a role of none or presentation" src="https://github.com/Azure/Commercial-Marketplace-SaaS-Accelerator/assets/132065894/51c44110-9646-4530-a4fc-9eb6ee418d2c">

- Heading hierarchy is not sequentially defined in the welcome admin page
<img width="909" alt="MAS1 3 1_Heading hierarchy is not sequentially defined in the welcome admin page" src="https://github.com/Azure/Commercial-Marketplace-SaaS-Accelerator/assets/132065894/fc3f930b-591b-45ad-953a-4bf1de39b4cb">

- Ensures every form element has a label
<img width="3200" alt="Note 1 - Ensures every form element has a label" src="https://github.com/Azure/Commercial-Marketplace-SaaS-Accelerator/assets/132065894/7242fc88-c77e-4301-a487-a770ae5c41fb">

- Ensures every id attribute value used in ARIA and in labels is unique
<img width="2942" alt="Note 1 - Ensures every id attribute value used in ARIA and in labels is unique" src="https://github.com/Azure/Commercial-Marketplace-SaaS-Accelerator/assets/132065894/24e29d48-fc09-41ec-8c89-918f54060eef">

- In aquatic and desert modes, 'Warning' icon in the dialog is not visible.
<img width="2034" alt="Note_1_ In aquatic and desert modes, 'Warning' icon in the dialog is not visible" src="https://github.com/Azure/Commercial-Marketplace-SaaS-Accelerator/assets/132065894/aae7f347-95e7-4166-91bb-34d8dc493b14">

- In aquatic and desert modes, visual borders of the 'Cancel' and 'OK' controls are not visible.
<img width="2034" alt="Note_1_In aquatic and desert modes, visual borders of the 'Cancel' and 'OK' controls are not visible" src="https://github.com/Azure/Commercial-Marketplace-SaaS-Accelerator/assets/132065894/b4b96d01-f35e-4139-9ffd-1d4b5d22f2e8">

- The text Subscriptions is visually appearing as heading but not programmatically set as heading.
<img width="1970" alt="Note 1 - The text 'Subscription details' is visually appearing as heading but not programmatically set as heading" src="https://github.com/Azure/Commercial-Marketplace-SaaS-Accelerator/assets/132065894/b1d5bb4f-0681-489b-8e5d-ca06b9556417">

- Heading h1 is not defined on the users page, while navigating using Heading shortcut key(H) Key.
![MAS1 3 1_Heading h1 is not defined on the users page, while navigating using Heading shortcut key(H) Key](https://github.com/Azure/Commercial-Marketplace-SaaS-Accelerator/assets/132065894/08988032-e628-4e05-a4b2-3228194efed6)

- Screen Reader is not narrating for required field
![MAS1 3 1_Screen Reader is not narrating 'Please fill out this field' information when focus lands on edit field present in the page](https://github.com/Azure/Commercial-Marketplace-SaaS-Accelerator/assets/132065894/d253370e-6787-4fe1-b32a-80010d0d731b)

- Incorrect role is defined for action menu button as link.
<img width="922" alt="Note_1_Incorrect role is defined for action menu button as link" src="https://github.com/Azure/Commercial-Marketplace-SaaS-Accelerator/assets/132065894/666e0441-101e-4bfe-b3d7-d569b56161b6">

- Ensures select element has an accessible name.
<img width="2956" alt="Note 1- Ensures select element has an accessible name" src="https://github.com/Azure/Commercial-Marketplace-SaaS-Accelerator/assets/132065894/d073e1b6-7e50-4e43-b260-77349d1dbebe">

- Screen reader is  announcing incorrect name for the 'Ok' button as 'Close' button.
<img width="959" alt="Note_1_Screen reader is  announcing incorrect name for the 'Ok' button as 'Close' button" src="https://github.com/Azure/Commercial-Marketplace-SaaS-Accelerator/assets/132065894/0e02790c-4164-43d2-afd9-8e8a67a71a84">
