### PR TITLE
Fixed scheduler time zone validation error

### DIFF
--- a/src/AdminSite/Controllers/SchedulerController.cs
+++ b/src/AdminSite/Controllers/SchedulerController.cs
@@ -234,7 +234,7 @@ public class SchedulerController : BaseController
                 PlanId = Convert.ToInt32(selectedDimension.PlanId),
                 DimensionId = Convert.ToInt32(schedulerUsageViewModel.SelectedDimension),
                 Quantity = Convert.ToDouble(schedulerUsageViewModel.Quantity),
-                StartDate = schedulerUsageViewModel.FirstRunDate
+                StartDate = schedulerUsageViewModel.FirstRunDate.AddHours(schedulerUsageViewModel.TimezoneOffset)
             };
             this.schedulerService.SaveSchedulerDetail(schedulerManagement);
             return this.RedirectToAction(nameof(this.Index));

--- a/src/AdminSite/Views/Scheduler/NewScheduler.cshtml
+++ b/src/AdminSite/Views/Scheduler/NewScheduler.cshtml
@@ -16,17 +16,26 @@
               });
               $("#SelectedDimension").html(subItems);
 
-              
             });
         });
 
         $("#btnSubmit").click(function () {
-                var dateElement=document.getElementById("FirstRunDate");
-                var date=new Date(dateElement.value);
-                var d=date.toISOString();
-                dateElement.value=d.slice(0,-5);
-         });
-        
+            var dateElement = document.getElementById("FirstRunDate");
+            var date = new Date(dateElement.value);
+
+            var year = date.getFullYear();
+            var month = (1 + date.getMonth()).toString().padStart(2, '0');
+            var day = date.getDate().toString().padStart(2, '0');
+            var hours = date.getHours().toString().padStart(2, '0');
+            var minutes = date.getMinutes().toString().padStart(2, '0');
+
+            var formattedDate = year + '-' + month + '-' + day + 'T' + hours + ':' + minutes;
+            dateElement.value = formattedDate;
+
+            var offset = new Date().getTimezoneOffset() / -60;
+            document.getElementById("TimezoneOffset").value = offset;
+
+        });
 
         $(document).ready(function() {
               var d = new Date();
@@ -123,6 +132,9 @@
 
                 </table>
             </div>
+
+            <input type="hidden" id="TimezoneOffset" name="TimezoneOffset" />
+
         </form>
     </div>
       

--- a/src/Services/Models/SchedulerUsageViewModel.cs
+++ b/src/Services/Models/SchedulerUsageViewModel.cs
@@ -81,4 +81,11 @@ public class SchedulerUsageViewModel
     /// 
     public List<MeteredAuditLogs> MeteredAuditLogs { get; set; }
 
+    /// <summary>
+    /// Gets or sets the user's timezone offset compared to UTC
+    /// </summary>
+    /// <value>
+    /// The user's timezone offset.
+    /// </value>
+    public int TimezoneOffset { get; set; }
 }


### PR DESCRIPTION
The date time conversion was happening inside the form element causing confusing UI and potential validation errors when treating local time as UTC. Proposed solution would be to keep everything locale-based on the client side, while doing any UTC conversions on the backend by passing in the `TimezoneOffset` parameter.