### PR TITLE
New scheduler - minutes fix

### DIFF
--- a/src/AdminSite/Views/Scheduler/NewScheduler.cshtml
+++ b/src/AdminSite/Views/Scheduler/NewScheduler.cshtml
@@ -32,7 +32,7 @@
               var output = d.getFullYear()+ '-' +
                           ((''+month).length<2 ? '0' : '') + month + '-' +
                            ((''+day).length<2 ? '0' : '') + day +'T'+
-                           ((''+d.getHours()).length<2 ? '0' : '')+d.getHours()+':'+
+                           ((''+d.getHours()).length<2 ? '0' : '')+(d.getHours()+1)+':'+
                            ((''+d.getMinutes()).length<2 ? '0' : '')+d.getMinutes();
 
               var date=document.getElementById("FirstRunDate")

--- a/src/DataAccess/Services/MeteredPlanSchedulerManagementRepository.cs
+++ b/src/DataAccess/Services/MeteredPlanSchedulerManagementRepository.cs
@@ -63,7 +63,7 @@ public class MeteredPlanSchedulerManagementRepository : IMeteredPlanSchedulerMan
         if (entity.StartDate.HasValue)
         {
             int minute = entity.StartDate.Value.Minute;
-            if (entity.StartDate.Value.Minute >= 30)
+            if (entity.StartDate.Value.Minute >= 30 || entity.StartDate.Value.ToUniversalTime() < DateTime.UtcNow)
             {
                 minute = 60 - entity.StartDate.Value.Minute;
                 entity.StartDate = entity.StartDate.Value.AddMinutes(minute);


### PR DESCRIPTION
**STR**
let's suppose that current time is 5:15pm

**current behavior**
1. create a new scheduler to run at 4:15pm - the form validation doesn't allow saving, because the time is in the past
2. create a new scheduler to run at 5:45pm - the form validation allows saving, because it is in the future, the StartDate is set to 6pm
3. create a new scheduler to run at 5:15pm - the form validation allows saving, because it is now, the StartDate is set to 5pm, which is in the past

**expected bahavior**
The form says that it rounds the minutes, so in case of current time, it should round the time to nearest hour in the future
