### PR TITLE
Fix performance when reading job LastRun

### DIFF
--- a/src/DataAccess/Contracts/ISchedulerManagerViewRepository.cs
+++ b/src/DataAccess/Contracts/ISchedulerManagerViewRepository.cs
@@ -14,7 +14,7 @@ public interface ISchedulerManagerViewRepository : IDisposable
     /// Get all scheduler Manager data
     /// </summary>
     /// <returns></returns>
-    IEnumerable<SchedulerManagerView> GetAll();
+    IEnumerable<SchedulerManagerViewExt> GetAll();
     /// <summary>
     /// Get  scheduler Manager data by Id
     /// </summary>

--- a/src/DataAccess/Entities/SchedulerManagerView.cs
+++ b/src/DataAccess/Entities/SchedulerManagerView.cs
@@ -16,3 +16,28 @@ public partial class SchedulerManagerView
     public DateTime StartDate { get; set; }
     public DateTime? NextRunTime { get; set; }
 }
+
+public class SchedulerManagerViewExt
+{
+    private readonly SchedulerManagerView v;
+
+    public SchedulerManagerViewExt(SchedulerManagerView schedulerManagerView)
+    {
+        this.v = schedulerManagerView;
+    }
+
+    public int? SubscriptionId { get; set; }
+
+    public int Id => v.Id;
+    public string SchedulerName => v.SchedulerName;
+    public string SubscriptionName => v.SubscriptionName;
+    public string PurchaserEmail => v.PurchaserEmail;
+    public Guid AMPSubscriptionId => v.AMPSubscriptionId;
+    public string PlanId => v.PlanId;
+    public string Dimension => v.Dimension;
+    public string Frequency => v.Frequency;
+    public double Quantity => v.Quantity;
+    public DateTime StartDate => v.StartDate;
+    public DateTime? NextRunTime => v.NextRunTime;
+
+}

--- a/src/DataAccess/Services/SchedulerManagerViewRepository.cs
+++ b/src/DataAccess/Services/SchedulerManagerViewRepository.cs
@@ -32,13 +32,18 @@ public class SchedulerManagerViewRepository : ISchedulerManagerViewRepository
     {
         this.context = context;
     }
+
     /// <summary>
-    /// Get all records for Scheduler Manager
+    /// Get all records for Scheduler Manager with SubscriptionId
     /// </summary>
     /// <returns></returns>
-    public IEnumerable<SchedulerManagerView> GetAll()
+    public IEnumerable<SchedulerManagerViewExt> GetAll()
     {
-        return this.context.SchedulerManagerView;
+        return this.context.SchedulerManagerView.Join(this.context.MeteredPlanSchedulerManagement, 
+            v => v.Id, 
+            m => m.Id,
+            (v, m) => new SchedulerManagerViewExt(v) { SubscriptionId = m.SubscriptionId })
+            .ToArray();
     }
 
     /// <summary>


### PR DESCRIPTION
The problem is that the code was repetitively trying to get subscription ID for all scheduled jobs. It means that for many jobs it is called really many times. I have rewritten the SQL so it returns the required information using JOIN, which is much faster.

Also I have implemented a memory cache per subscription ID, because if we have n jobs for every subscription it doesn't make sense to fetch everything n times. The audit log can be large especially if we are talking about daily jobs.