### PR TITLE
Remove hardcoded "AMPSaaSDB" in deployment script connection string

### DIFF
--- a/deployment/Deploy.ps1
+++ b/deployment/Deploy.ps1
@@ -279,7 +279,7 @@ $WebAppNamePortal=$WebAppNamePrefix+"-portal"
 $ADApplicationSecretKeyVault="@Microsoft.KeyVault(VaultName=$KeyVault;SecretName=ADApplicationSecret) "
 $DefaultConnectionKeyVault="@Microsoft.KeyVault(VaultName=$KeyVault;SecretName=DefaultConnection) "
 $ServerUri = $SQLServerName+".database.windows.net"
-$Connection="Data Source=tcp:"+$ServerUri+",1433;Initial Catalog=AMPSaaSDB;User Id="+$SQLAdminLogin+"@"+$SQLServerName+".database.windows.net;Password="+$SQLAdminLoginPassword+";"
+$Connection="Data Source=tcp:"+$ServerUri+",1433;Initial Catalog="+$SQLDatabaseName+";User Id="+$SQLAdminLogin+"@"+$SQLServerName+".database.windows.net;Password="+$SQLAdminLoginPassword+";"
 
 
 Write-host "   🔵 Resource Group"


### PR DESCRIPTION
The SaaS Accelerator hardcodes the default database name when setting the Connection String before web app publish. This will cause errors in case the database name is overridden.

Changing the value to use the `$SQLDatabaseName` parameter instead.