### PR TITLE
Fetch SMTP password from KeyVault

### DIFF
--- a/src/Services/Helpers/EmailHelper.cs
+++ b/src/Services/Helpers/EmailHelper.cs
@@ -133,7 +133,7 @@ public class EmailHelper
         emailContent.Body = body;
         emailContent.CopyToCustomer = copyToCustomer;
         emailContent.FromEmail = this.applicationConfigRepository.GetValueByName("SMTPFromEmail");
-        emailContent.Password = this.applicationConfigRepository.GetValueByName("SMTPPassword");
+        emailContent.Password = KeyVaultReferenceResolver.ProcessKeyVaultReference(this.applicationConfigRepository.GetValueByName("SMTPPassword"));
         emailContent.SSL = bool.Parse(this.applicationConfigRepository.GetValueByName("SMTPSslEnabled"));
         emailContent.UserName = this.applicationConfigRepository.GetValueByName("SMTPUserName");
         emailContent.Port = int.Parse(this.applicationConfigRepository.GetValueByName("SMTPPort"));

--- a/src/Services/Helpers/KeyVaultReferenceResolver.cs
+++ b/src/Services/Helpers/KeyVaultReferenceResolver.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Text.RegularExpressions;
+using Azure.Identity;
+using Azure.Security.KeyVault.Secrets;
+
+namespace Marketplace.SaaS.Accelerator.Services.Helpers;
+
+public partial class KeyVaultReferenceResolver
+{
+    private struct KeyVaultReference
+    {
+        public string VaultName { get; }
+        public string SecretName { get; }
+
+        public KeyVaultReference(string vaultName, string secretName)
+        {
+            VaultName = vaultName;
+            SecretName = secretName;
+        }
+    }
+
+    private static readonly Regex KeyVaultReferenceRegex = new("^@Microsoft\\.KeyVault\\(VaultName=(?<vaultName>[^,]+);SecretName=(?<secretName>[^,]+)\\)$");
+
+    public static string ProcessKeyVaultReference(string secret)
+    {
+        if (string.IsNullOrWhiteSpace(secret))
+            return secret;
+
+        if (secret.StartsWith("@Microsoft.KeyVault"))
+        {
+            var kv = ParseKeyVaultReferenceUsingRegex(secret);
+            return GetSecretFromKeyVault(kv);
+        }
+
+        return secret;
+    }
+
+    private static KeyVaultReference ParseKeyVaultReferenceUsingRegex(string kvReference)
+    {
+        var re = KeyVaultReferenceRegex.Match(kvReference);
+        return new KeyVaultReference(re.Groups["vaultName"].Value, re.Groups["secretName"].Value);
+    }
+
+    private static string GetSecretFromKeyVault(KeyVaultReference kv)
+    {
+        var kvUri = "https://" + kv.VaultName + ".vault.azure.net";
+
+        var client = new SecretClient(new Uri(kvUri), new DefaultAzureCredential());
+
+        return client.GetSecret(kv.SecretName).Value.Value;
+    }
+}

--- a/src/Services/Services.csproj
+++ b/src/Services/Services.csproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.5.0" />
     <PackageReference Include="Marketplace.SaaS.Client" Version="1.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />


### PR DESCRIPTION
This change avoids storing the password as plain text in database and instead allows the accelerator to fetch password from Key Vault. Just configure the SMTPPassword setting on UI with the pattern pointing to the keyvault secret:
```
@Microsoft.KeyVault(VaultName=webapp-prefix-kv;SecretName=SMTPPassword)
```