### PR TITLE
Chromedrive upgrade to 118

### DIFF
--- a/src/UI.Test/UI.Test.csproj
+++ b/src/UI.Test/UI.Test.csproj
@@ -22,12 +22,12 @@
 	  <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.4" />
 	  <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />
 	  <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
-	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
 	  <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
 	  <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
 	  <PackageReference Include="coverlet.collector" Version="6.0.0" />
-	  <PackageReference Include="Selenium.WebDriver" Version="4.11.0" />
-	  <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="116.0.5845.9600" />
+	  <PackageReference Include="Selenium.WebDriver" Version="4.15.0" />
+	  <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="118.0.5993.7000" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
 Initialization method Marketplace.SaaS.Accelerator.UI.Test.CustomerApplicationShould.Setup threw exception. System.InvalidOperationException: session not created: This version of ChromeDriver only supports Chrome version 116
Current browser version is 118.0.5993.117 