### PR TITLE
update appconfig to save empty string instead of null #619

### DIFF
--- a/src/AdminSite/Controllers/ApplicationConfigController.cs
+++ b/src/AdminSite/Controllers/ApplicationConfigController.cs
@@ -119,6 +119,7 @@ public class ApplicationConfigController : BaseController
     [ValidateAntiForgeryToken]
     public IActionResult ApplicationConfigDetails(ApplicationConfiguration appConfig)
     {
+        appConfig.Value = appConfig.Value ?? string.Empty;
         this.appConfigService.SaveAppConfig(appConfig);
 
         this.ModelState.Clear();

--- a/src/AdminSite/Views/ApplicationConfig/ApplicationConfigDetails.cshtml
+++ b/src/AdminSite/Views/ApplicationConfig/ApplicationConfigDetails.cshtml
@@ -25,7 +25,7 @@
                         @Model.Name
                     </td>
                     <td>
-                        @if (@Model.Name.Equals("SMTPPassword") && @Model.Value.Length > 5)
+                        @if (@Model.Name.Equals("SMTPPassword") && @Model?.Value?.Length > 5)
                         {
                             @Html.EditorFor(model => model.Value, new { htmlAttributes = new { type ="password", @class = "form-control" } })
                         }

--- a/src/AdminSite/Views/ApplicationConfig/Index.cshtml
+++ b/src/AdminSite/Views/ApplicationConfig/Index.cshtml
@@ -31,7 +31,7 @@
                                         @item.Name
                                     </td>
                                     <td class="text-left">
-                                        @if (@item.Name.Equals("SMTPPassword") && @item.Value.Length > 5)
+                                        @if (@item.Name.Equals("SMTPPassword") && @item?.Value?.Length > 5)
                                         {
                                             @String.Format("{0}{1}", @item.Value.Substring(0,5), "****************");
                                         }


### PR DESCRIPTION
When clearing out any app config value it saving them as null. And as one of the values is checked for length, its throwing an error. Fixed both when saving and when displaying.