### PR TITLE
Fix New Scheduler add hour Javascipt logic

### DIFF
--- a/src/AdminSite/Views/Scheduler/NewScheduler.cshtml
+++ b/src/AdminSite/Views/Scheduler/NewScheduler.cshtml
@@ -27,7 +27,7 @@
         });
 
         $(document).ready(function() {
-              var d =  new Date.addHours(1);
+              var d =  new Date().addHours(1);
               var month = d.getMonth()+1;
               var day = d.getDate();
               var minutes = d.getMinutes();

--- a/src/AdminSite/Views/Scheduler/NewScheduler.cshtml
+++ b/src/AdminSite/Views/Scheduler/NewScheduler.cshtml
@@ -32,7 +32,7 @@
               var month = d.getMonth()+1;
               var day = d.getDate();
               var minutes = d.getMinutes();
-
+              var hours=d.getHours();
               var output = d.getFullYear()+ '-' +
                           ((''+month).length<2 ? '0' : '') + month + '-' +
                            ((''+day).length<2 ? '0' : '') + day +'T'+

--- a/src/AdminSite/Views/Scheduler/NewScheduler.cshtml
+++ b/src/AdminSite/Views/Scheduler/NewScheduler.cshtml
@@ -27,7 +27,8 @@
         });
 
         $(document).ready(function() {
-              var d =  new Date().addHours(1);
+              var d =  new Date();
+              d.setHours(d.getHours() + 1);
               var month = d.getMonth()+1;
               var day = d.getDate();
               var minutes = d.getMinutes();

--- a/src/AdminSite/Views/Scheduler/NewScheduler.cshtml
+++ b/src/AdminSite/Views/Scheduler/NewScheduler.cshtml
@@ -30,11 +30,14 @@
               var d = new Date();
               var month = d.getMonth()+1;
               var day = d.getDate();
+              var hours =d.getHours()+1;
+              var minutes = d.getMinutes();
+
               var output = d.getFullYear()+ '-' +
                           ((''+month).length<2 ? '0' : '') + month + '-' +
                            ((''+day).length<2 ? '0' : '') + day +'T'+
-                           ((''+d.getHours()).length<2 ? '0' : '')+(d.getHours()+1)+':'+
-                           ((''+d.getMinutes()).length<2 ? '0' : '')+d.getMinutes();
+                           ((''+hours).length<2 ? '0' : '')+hours+':'+
+                           ((''+minutes).length<2 ? '0' : '')+minutes;
 
               var date=document.getElementById("FirstRunDate")
               date.min=output

--- a/src/AdminSite/Views/Scheduler/NewScheduler.cshtml
+++ b/src/AdminSite/Views/Scheduler/NewScheduler.cshtml
@@ -27,10 +27,9 @@
         });
 
         $(document).ready(function() {
-              var d = new Date();
+              var d =  new Date.addHours(1);
               var month = d.getMonth()+1;
               var day = d.getDate();
-              var hours =d.getHours()+1;
               var minutes = d.getMinutes();
 
               var output = d.getFullYear()+ '-' +


### PR DESCRIPTION
Current JS logic will pad leading zero then add hour in same time. The logic will break in case of hour=9

The new logic will add the hour first then go through the logic of leading zero