### PR TITLE
Allow Existing KeyVault to process withput breaking

### DIFF
--- a/deployment/Deploy.ps1
+++ b/deployment/Deploy.ps1
@@ -54,7 +54,7 @@ if($KeyVault -eq "")
    $KeyVault=$WebAppNamePrefix+"-kv"
 
    # Check if the KeyVault exists under resource group
-   $kv_check=$(az keyvault show -n $KeyVault -g $ResourceGroupForDeployment)     
+   $kv_check=$(az keyvault show -n $KeyVault -g $ResourceGroupForDeployment) 2>$null    
 
    # If KeyVault does not exist under resource group, then we need to check if it deleted KeyVault
    if($kv_check -eq $null)

--- a/deployment/Deploy.ps1
+++ b/deployment/Deploy.ps1
@@ -68,12 +68,12 @@ if($KeyVault -eq "")
 		if( $kv_check.reason -eq "AlreadyExists")
 		{
 			Write-Host ""
-			Write-Host "🛑 KeyVault name "  -NoNewline -ForegroundColor Red
+			Write-Host "🛑    KeyVault name "  -NoNewline -ForegroundColor Red
 			Write-Host "$KeyVault"  -NoNewline -ForegroundColor Red -BackgroundColor Yellow
 			Write-Host " already exists." -ForegroundColor Red
-			Write-Host "To Purge KeyVault please use the following doc:"
-			Write-Host "https://learn.microsoft.com/en-us/cli/azure/keyvault?view=azure-cli-latest#az-keyvault-purge."
-			Write-Host "You could use new KeyVault name by using parameter" -NoNewline 
+			Write-Host "  To Purge KeyVault please use the following doc:"
+			Write-Host "  https://learn.microsoft.com/en-us/cli/azure/keyvault?view=azure-cli-latest#az-keyvault-purge."
+			Write-Host "  You could use new KeyVault name by using parameter" -NoNewline 
 			Write-Host " -KeyVault"  -ForegroundColor Green
 			exit 1
 		}

--- a/deployment/Deploy.ps1
+++ b/deployment/Deploy.ps1
@@ -68,7 +68,7 @@ if($KeyVault -eq "")
 		if( $kv_check.reason -eq "AlreadyExists")
 		{
 			Write-Host ""
-			Write-Host "🛑    KeyVault name "  -NoNewline -ForegroundColor Red
+			Write-Host "🛑  KeyVault name "  -NoNewline -ForegroundColor Red
 			Write-Host "$KeyVault"  -NoNewline -ForegroundColor Red -BackgroundColor Yellow
 			Write-Host " already exists." -ForegroundColor Red
 			Write-Host "  To Purge KeyVault please use the following doc:"

--- a/deployment/Deploy.ps1
+++ b/deployment/Deploy.ps1
@@ -71,9 +71,9 @@ if($KeyVault -eq "")
 			Write-Host "🛑  KeyVault name "  -NoNewline -ForegroundColor Red
 			Write-Host "$KeyVault"  -NoNewline -ForegroundColor Red -BackgroundColor Yellow
 			Write-Host " already exists." -ForegroundColor Red
-			Write-Host "  To Purge KeyVault please use the following doc:"
-			Write-Host "  https://learn.microsoft.com/en-us/cli/azure/keyvault?view=azure-cli-latest#az-keyvault-purge."
-			Write-Host "  You could use new KeyVault name by using parameter" -NoNewline 
+			Write-Host "   To Purge KeyVault please use the following doc:"
+			Write-Host "   https://learn.microsoft.com/en-us/cli/azure/keyvault?view=azure-cli-latest#az-keyvault-purge."
+			Write-Host "   You could use new KeyVault name by using parameter" -NoNewline 
 			Write-Host " -KeyVault"  -ForegroundColor Green
 			exit 1
 		}

--- a/deployment/Deploy.ps1
+++ b/deployment/Deploy.ps1
@@ -48,7 +48,38 @@ if ($SQLDatabaseName -eq "") {
 
 if($KeyVault -eq "")
 {
+# User did not define KeyVault, so we will create one. 
+# We need to check if the KeyVault already exists or purge before going forward
+
    $KeyVault=$WebAppNamePrefix+"-kv"
+
+   # Check if the KeyVault exists under resource group
+   $kv_check=$(az keyvault show -n $KeyVault -g $ResourceGroupForDeployment)     
+
+   # If KeyVault does not exist under resource group, then we need to check if it deleted KeyVault
+   if($kv_check -eq $null)
+   {
+	#region Check If KeyVault Exists
+		$KeyVaultApiUri="https://management.azure.com/subscriptions/$AzureSubscriptionID/providers/Microsoft.KeyVault/checkNameAvailability?api-version=2019-09-01"
+		$KeyVaultApiBody='{"name": "'+$KeyVault+'","type": "Microsoft.KeyVault/vaults"}'
+
+		$kv_check=az rest --method post --uri $KeyVaultApiUri --headers 'Content-Type=application/json' --body $KeyVaultApiBody | ConvertFrom-Json
+
+		if( $kv_check.reason -eq "AlreadyExists")
+		{
+			Write-Host ""
+			Write-Host "🛑 KeyVault name "  -NoNewline -ForegroundColor Red
+			Write-Host "$KeyVault"  -NoNewline -ForegroundColor Red -BackgroundColor Yellow
+			Write-Host " already exists." -ForegroundColor Red
+			Write-Host "To Purge KeyVault please use the following doc:"
+			Write-Host "https://learn.microsoft.com/en-us/cli/azure/keyvault?view=azure-cli-latest#az-keyvault-purge."
+			Write-Host "You could use new KeyVault name by using parameter" -NoNewline 
+			Write-Host " -KeyVault"  -ForegroundColor Green
+			exit 1
+		}
+	#endregion
+	}
+
 }
 
 $SaaSApiConfiguration_CodeHash= git log --format='%H' -1
@@ -63,11 +94,11 @@ if($WebAppNamePrefix.Length -gt 21) {
     exit 1
 }
 
-
 if(!($KeyVault -match "^[a-zA-Z][a-z0-9-]+$")) {
     Throw "🛑 KeyVault name only allows alphanumeric and hyphens, but cannot start with a number or special character."
     exit 1
 }
+
 
 #endregion 
 
@@ -117,30 +148,6 @@ Write-Host "🔑 Azure Subscription '$AzureSubscriptionID' selected."
 
 #endregion
 
-#region Check if KV exists
-
-#region Check If KeyVault Exists
-
-$KeyVaultApiUri="https://management.azure.com/subscriptions/$AzureSubscriptionID/providers/Microsoft.KeyVault/checkNameAvailability?api-version=2019-09-01"
-$KeyVaultApiBody='{"name": "'+$KeyVault+'","type": "Microsoft.KeyVault/vaults"}'
-
-$kv_check=az rest --method post --uri $KeyVaultApiUri --headers 'Content-Type=application/json' --body $KeyVaultApiBody | ConvertFrom-Json
-
-if( $kv_check.reason -eq "AlreadyExists")
-{
-	Write-Host ""
-	Write-Host "🛑 KeyVault name "  -NoNewline -ForegroundColor Red
-	Write-Host "$KeyVault"  -NoNewline -ForegroundColor Red -BackgroundColor Yellow
-	Write-Host " already exists." -ForegroundColor Red
-	Write-Host "To Purge KeyVault please use the following doc:"
-	Write-Host "https://learn.microsoft.com/en-us/cli/azure/keyvault?view=azure-cli-latest#az-keyvault-purge."
-	Write-Host "You could use new KeyVault name by using parameter" -NoNewline 
-	Write-Host " -KeyVault"  -ForegroundColor Green
-    exit 1
-}
-
-
-#endregion
 
 #region Check If SQL Server Exist
 $sql_exists = Get-AzureRmSqlServer -ServerName $SQLServerName -ResourceGroupName $ResourceGroupForDeployment -ErrorAction SilentlyContinue


### PR DESCRIPTION
If user passed KeyVault name or Accelerator deployed over existing resouces, Script will exist due to existing KeyVault and direct user to purge KeyVault.

**Solution:**
1- If user provided KeyVault name, Deployment script will by pass the validation. It is user responsibility to provide existing valid KeyVault name
2- If Deployment used auto generated keyvault name then there is two different actions:
- If KeyVault exists then it will pass and proceed with deployment. 
- If KeyVault does not exist then it will check if the KeyVault was deleted before or not.



