### PR TITLE
Move modals outside of form elements

### DIFF
--- a/src/AdminSite/Views/Home/Subscriptions.cshtml
+++ b/src/AdminSite/Views/Home/Subscriptions.cshtml
@@ -128,25 +128,25 @@
                     </div>
                 </div>
             </div>
-            <!-- Modal -->
-            <div class="modal" id="myModal" tabindex="-1">
-                <div class="modal-dialog">
-                    @* <div class="modal-content">
-                        <div class="modal-header">
-                            <h5 class="modal-title" id="exampleModalLabel">Modal title</h5>
-                            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-                        </div> *@
-                        @* <div class="modal-body">
-
-                        </div>
-                        <div class="modal-footer">
-
-
-                        </div> *@
-                   @*  </div> *@
-                </div>
-            </div>
         </form>
+        <!-- Modal -->
+        <div class="modal" id="myModal" tabindex="-1">
+            <div class="modal-dialog">
+                @* <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title" id="exampleModalLabel">Modal title</h5>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                    </div> *@
+                    @* <div class="modal-body">
+
+                    </div>
+                    <div class="modal-footer">
+
+
+                    </div> *@
+                @*  </div> *@
+            </div>
+        </div>
     </div>
 </div>
 

--- a/src/CustomerSite/Views/Home/Subscriptions.cshtml
+++ b/src/CustomerSite/Views/Home/Subscriptions.cshtml
@@ -115,28 +115,25 @@
                 Launch demo modal
             </button> *@
             <p></p>
-            <!-- Modal -->
-            <div class="modal" id="myModal" tabindex="-1" aria-labelledby="exampleModalLabel" aria-hidden="true">
-                <div class="modal-dialog">
-                    <div class="modal-content">
-                        <div class="modal-header">
-                            <h5 class="modal-title" id="exampleModalLabel">Modal title</h5>
-                            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-                        </div>
-                        @* <div class="modal-body">
-                            
-                        </div>
-                        <div class="modal-footer">
-                            
-                            
-                        </div> *@
+        </form>
+        <!-- Modal -->
+        <div class="modal" id="myModal" tabindex="-1" aria-labelledby="exampleModalLabel" aria-hidden="true">
+            <div class="modal-dialog">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title" id="exampleModalLabel">Modal title</h5>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                     </div>
+                    @* <div class="modal-body">
+                        
+                    </div>
+                    <div class="modal-footer">
+                        
+                        
+                    </div> *@
                 </div>
             </div>
-
-
-            
-        </form>
+        </div>
     </div>
 </div>
 


### PR DESCRIPTION
The modals in both the admin and landing page subscription lists were not working. The spinner would keep spinning indefinitely after the user pressed the button.

The cause was that the form element that the JavaScript attempted to submit did not exist. The form was nested within another form. As a result, the browser removed it from the DOM.

This change moves the modal container outside of the outer form element so that it's inner form would not be nested.