### PR TITLE
Fix Subscription Api error

### DIFF
--- a/deployment/Deploy.ps1
+++ b/deployment/Deploy.ps1
@@ -33,6 +33,38 @@ Param(
 # Install-Module Az
 # Install-Module -Name AzureAD
 
+#region Select Tenant / Subscription for deployment
+
+$currentContext = az account show | ConvertFrom-Json
+$currentTenant = $currentContext.tenantId
+$currentSubscription = $currentContext.id
+
+#Get TenantID if not set as argument
+if(!($TenantID)) {    
+    Get-AzTenant | Format-Table
+    if (!($TenantID = Read-Host "⌨  Type your TenantID or press Enter to accept your current one [$currentTenant]")) { $TenantID = $currentTenant }    
+}
+else {
+    Write-Host "🔑 Tenant provided: $TenantID"
+}
+
+#Get Azure Subscription if not set as argument
+if(!($AzureSubscriptionID)) {    
+    Get-AzSubscription -TenantId $TenantID | Format-Table
+    if (!($AzureSubscriptionID = Read-Host "⌨  Type your SubscriptionID or press Enter to accept your current one [$currentSubscription]")) { $AzureSubscriptionID = $currentSubscription }
+}
+else {
+    Write-Host "🔑 Azure Subscription provided: $AzureSubscriptionID"
+}
+
+#Set the AZ Cli context
+az account set -s $AzureSubscriptionID
+Write-Host "🔑 Azure Subscription '$AzureSubscriptionID' selected."
+
+#endregion
+
+
+
 $ErrorActionPreference = "Stop"
 $startTime = Get-Date
 #region Set up Variables and Default Parameters
@@ -118,37 +150,6 @@ if(!$dotnetversion.StartsWith('6.')) {
 
 
 Write-Host "Starting SaaS Accelerator Deployment..."
-
-#region Select Tenant / Subscription for deployment
-
-$currentContext = az account show | ConvertFrom-Json
-$currentTenant = $currentContext.tenantId
-$currentSubscription = $currentContext.id
-
-#Get TenantID if not set as argument
-if(!($TenantID)) {    
-    Get-AzTenant | Format-Table
-    if (!($TenantID = Read-Host "⌨  Type your TenantID or press Enter to accept your current one [$currentTenant]")) { $TenantID = $currentTenant }    
-}
-else {
-    Write-Host "🔑 Tenant provided: $TenantID"
-}
-
-#Get Azure Subscription if not set as argument
-if(!($AzureSubscriptionID)) {    
-    Get-AzSubscription -TenantId $TenantID | Format-Table
-    if (!($AzureSubscriptionID = Read-Host "⌨  Type your SubscriptionID or press Enter to accept your current one [$currentSubscription]")) { $AzureSubscriptionID = $currentSubscription }
-}
-else {
-    Write-Host "🔑 Azure Subscription provided: $AzureSubscriptionID"
-}
-
-#Set the AZ Cli context
-az account set -s $AzureSubscriptionID
-Write-Host "🔑 Azure Subscription '$AzureSubscriptionID' selected."
-
-#endregion
-
 
 #region Check If SQL Server Exist
 $sql_exists = Get-AzureRmSqlServer -ServerName $SQLServerName -ResourceGroupName $ResourceGroupForDeployment -ErrorAction SilentlyContinue


### PR DESCRIPTION
## Description

This PR addresses a critical issue in the deployment script (`Deploy.ps1`) where an API call is made to check if a KeyVault (KV) exists before the `subscriptionID` is properly assigned. This premature API call results in an error due to the lack of a valid `subscriptionID`. The error message encountered is as follows:
`
ERROR: Bad Request({"error":{"code":"InvalidSubscriptionId","message":"The provided subscription identifier 'providers' is malformed or invalid."}}) 
`

## Changes Made

- Modified the `Deploy.ps1` script to ensure that the `subscriptionID` is assigned before any API calls are made. This change prevents the aforementioned error by ensuring that a valid `subscriptionID` is available for the API call that checks for the existence of a KeyVault.

## Impact

- This change fixes the deployment failure issue by correcting the order of operations in the script. By setting the `subscriptionID` before making the API call, we avoid the `InvalidSubscriptionId` error and ensure a smoother deployment process.

## Testing

- The updated script has been tested to confirm that the `subscriptionID` is correctly assigned before the API call is made. This ensures that the deployment process proceeds without encountering the `InvalidSubscriptionId` error.

## Conclusion

This PR resolves a critical bug in the deployment process by adjusting the sequence of operations in the `Deploy.ps1` script, thereby ensuring a successful deployment without errors related to the `subscriptionID`.