### PR TITLE
Deploy fix

### DIFF
--- a/deployment/Deploy.ps1
+++ b/deployment/Deploy.ps1
@@ -10,6 +10,25 @@
 # -Location "<region>" `
 # -PublisherAdminUsers "<your@email.address>"
 
+Param(  
+   [string][Parameter(Mandatory)]$WebAppNamePrefix, # Prefix used for creating web applications
+   [string][Parameter()]$ResourceGroupForDeployment, # Name of the resource group to deploy the resources
+   [string][Parameter(Mandatory)]$Location, # Location of the resource group
+   [string][Parameter(Mandatory)]$PublisherAdminUsers, # Provide a list of email addresses (as comma-separated-values) that should be granted access to the Publisher Portal
+   [string][Parameter()]$TenantID, # The value should match the value provided for Active Directory TenantID in the Technical Configuration of the Transactable Offer in Partner Center
+   [string][Parameter()]$AzureSubscriptionID, # Subscription where the resources be deployed
+   [string][Parameter()]$ADApplicationID, # The value should match the value provided for Active Directory Application ID in the Technical Configuration of the Transactable Offer in Partner Center
+   [string][Parameter()]$ADApplicationSecret, # Secret key of the AD Application
+   [string][Parameter()]$ADMTApplicationIDAdmin, # Multi-Tenant Active Directory Application ID for the Admin Portal
+   [string][Parameter()]$ADMTApplicationIDPortal, #Multi-Tenant Active Directory Application ID for the Landing Portal
+   [string][Parameter()]$SQLDatabaseName, # Name of the database (Defaults to AMPSaaSDB)
+   [string][Parameter()]$SQLServerName, # Name of the database server (without database.windows.net)
+   [string][Parameter()]$LogoURLpng,  # URL for Publisher .png logo
+   [string][Parameter()]$LogoURLico,  # URL for Publisher .ico logo
+   [string][Parameter()]$KeyVault, # Name of KeyVault
+   [switch][Parameter()]$Quiet #if set, only show error / warning output from script commands
+)
+
 # Define the warning message
 $message = @"
 The SaaS Accelerator is offered under the MIT License as open source software and is not supported by Microsoft.
@@ -33,26 +52,6 @@ if ($response -ne 'Y' -and $response -ne 'y') {
 
 # Proceed if the user agrees
 Write-Host "Thank you for agreeing. Proceeding with the script..." -ForegroundColor Green
- 
-
-Param(  
-   [string][Parameter(Mandatory)]$WebAppNamePrefix, # Prefix used for creating web applications
-   [string][Parameter()]$ResourceGroupForDeployment, # Name of the resource group to deploy the resources
-   [string][Parameter(Mandatory)]$Location, # Location of the resource group
-   [string][Parameter(Mandatory)]$PublisherAdminUsers, # Provide a list of email addresses (as comma-separated-values) that should be granted access to the Publisher Portal
-   [string][Parameter()]$TenantID, # The value should match the value provided for Active Directory TenantID in the Technical Configuration of the Transactable Offer in Partner Center
-   [string][Parameter()]$AzureSubscriptionID, # Subscription where the resources be deployed
-   [string][Parameter()]$ADApplicationID, # The value should match the value provided for Active Directory Application ID in the Technical Configuration of the Transactable Offer in Partner Center
-   [string][Parameter()]$ADApplicationSecret, # Secret key of the AD Application
-   [string][Parameter()]$ADMTApplicationIDAdmin, # Multi-Tenant Active Directory Application ID for the Admin Portal
-   [string][Parameter()]$ADMTApplicationIDPortal, #Multi-Tenant Active Directory Application ID for the Landing Portal
-   [string][Parameter()]$SQLDatabaseName, # Name of the database (Defaults to AMPSaaSDB)
-   [string][Parameter()]$SQLServerName, # Name of the database server (without database.windows.net)
-   [string][Parameter()]$LogoURLpng,  # URL for Publisher .png logo
-   [string][Parameter()]$LogoURLico,  # URL for Publisher .ico logo
-   [string][Parameter()]$KeyVault, # Name of KeyVault
-   [switch][Parameter()]$Quiet #if set, only show error / warning output from script commands
-)
 
 # Make sure to install Az Module before running this script
 # Install-Module Az

--- a/deployment/Upgrade.ps1
+++ b/deployment/Upgrade.ps1
@@ -5,6 +5,11 @@
 # Powershell script to deploy the resources - Customer portal, Publisher portal and the Azure SQL Database
 #
 
+Param(  
+   [string][Parameter(Mandatory)]$WebAppNamePrefix, # Prefix used for creating web applications
+   [string][Parameter(Mandatory)]$ResourceGroupForDeployment # Name of the resource group to deploy the resources
+)
+
 # Define the message
 $message = @"
 The SaaS Accelerator is offered under the MIT License as open source software and is not supported by Microsoft.
@@ -28,11 +33,6 @@ if ($response -ne 'Y' -and $response -ne 'y') {
 
 # Proceed if the user agrees
 Write-Host "Thank you for agreeing. Proceeding with the script..." -ForegroundColor Green
-
-Param(  
-   [string][Parameter(Mandatory)]$WebAppNamePrefix, # Prefix used for creating web applications
-   [string][Parameter(Mandatory)]$ResourceGroupForDeployment # Name of the resource group to deploy the resources
-)
 
 Function String-Between
 {


### PR DESCRIPTION
This pull request primarily focuses on refactoring the PowerShell scripts `Deploy.ps1` and `Upgrade.ps1` in the `deployment` directory. The changes involve repositioning the `Param` blocks in both scripts to be at the top of the file, right after the initial comments. 

Changes in `Deploy.ps1`:
* The `Param` block, which declares various parameters required for deployment, has been moved to the top of the script. This block was previously located inside an `if` statement. The parameters include the web application name prefix, resource group for deployment, location, publisher admin users, tenant ID, Azure subscription ID, Active Directory application ID and secret, multi-tenant Active Directory application ID for admin and landing portal, SQL database name, SQL server name, logo URLs, KeyVault name, and a quiet switch. [[1]](diffhunk://#diff-945908cece7ba32245d369c8e39d64bc1d6c4bd58abf5a9db9829e0c1ab23449R13-R31) [[2]](diffhunk://#diff-945908cece7ba32245d369c8e39d64bc1d6c4bd58abf5a9db9829e0c1ab23449L37-L56)

Changes in `Upgrade.ps1`:
* Similar to `Deploy.ps1`, the `Param` block in `Upgrade.ps1` has been moved to the top of the script. This block declares the web application name prefix and the resource group for deployment as mandatory parameters. [[1]](diffhunk://#diff-83fee3f1c09234ade18bc8f561e2e95ce363baf8136ca50c9a5aa30b266aaeecR8-R12) [[2]](diffhunk://#diff-83fee3f1c09234ade18bc8f561e2e95ce363baf8136ca50c9a5aa30b266aaeecL32-L36)

These changes enhance the readability and maintainability of the scripts by following the common practice of defining parameters at the beginning of the script.

![image](https://github.com/user-attachments/assets/ba9f7af9-668a-4e30-ab23-8bbfae4c6053)
