### PR TITLE
Add file name and executable file validation.

### DIFF
--- a/src/AdminSite/Controllers/ApplicationConfigController.cs
+++ b/src/AdminSite/Controllers/ApplicationConfigController.cs
@@ -171,6 +171,25 @@ public class ApplicationConfigController : BaseController
             }
 
             var fileExtension = Path.GetExtension(file.FileName).ToLowerInvariant();
+            int dotCount = Path.GetFileNameWithoutExtension(file.FileName).Count(f => f == '.');
+
+            if (dotCount > 1)
+            {
+                TempData["Upload"] = "File name cannot contain more than one period";
+                return RedirectToAction("Index");
+            }
+
+            using (var stream = file.OpenReadStream())
+            {
+                byte[] buffer = new byte[2];
+                stream.Read(buffer, 0, 2);
+                bool isExecutableFile = buffer[0] == 0x4D && buffer[1] == 0x5A;
+                if (isExecutableFile)
+                {
+                    TempData["Upload"] = "Executable files are not allowed";
+                    return RedirectToAction("Index");
+                }
+            }
 
             if (fileExtension != ".png" && fileExtension != ".ico")
             {


### PR DESCRIPTION
Added a check to ensure that the file name does not contain more than one period. If it does, an error message is set in `TempData` and the user is redirected to the "Index" action.

Introduced a new block of code that reads the first two bytes of the uploaded file to determine if it is an executable file (by checking for the "MZ" header). If the file is identified as an executable, an error message is set in `TempData` and the user is redirected to the "Index" action.