### PR TITLE
Add validation for file name periods and executable files

### DIFF
--- a/src/AdminSite/Controllers/ApplicationConfigController.cs
+++ b/src/AdminSite/Controllers/ApplicationConfigController.cs
@@ -171,6 +171,25 @@ public class ApplicationConfigController : BaseController
             }
 
             var fileExtension = Path.GetExtension(file.FileName).ToLowerInvariant();
+            int dotCount = Path.GetFileNameWithoutExtension(file.FileName).Count(f => f == '.');
+
+            if (dotCount > 1)
+            {
+                TempData["Upload"] = "File name cannot contain more than one period";
+                return RedirectToAction("Index");
+            }
+
+            using (var stream = file.OpenReadStream())
+            {
+                byte[] buffer = new byte[2];
+                stream.Read(buffer, 0, 2);
+                bool isExecutableFile = buffer[0] == 0x4D && buffer[1] == 0x5A;
+                if (isExecutableFile)
+                {
+                    TempData["Upload"] = "Executable files are not allowed";
+                    return RedirectToAction("Index");
+                }
+            }
 
             if (fileExtension != ".png" && fileExtension != ".ico")
             {


### PR DESCRIPTION
Introduced two new validation checks in the ApplicationConfigController:
1. File Name Period Check: Ensures file names have no more than one period (excluding the extension) to prevent security issues.
2. Executable File Check: Detects and blocks executable files by checking for the 'MZ' header, enhancing security against potentially harmful uploads.