### PR TITLE
Simplified logic to show three part version, removing the revision

### DIFF
--- a/src/AdminSite/Startup.cs
+++ b/src/AdminSite/Startup.cs
@@ -141,14 +141,11 @@ public class Startup
             .AddSingleton<SaaSApiClientConfiguration>(config)
             .AddSingleton<KnownUsersModel>(knownUsers);
 
-        // Read the versionInfo and Add to services
-        var versionInfo = FileVersionInfo.GetVersionInfo(Assembly.GetExecutingAssembly().Location);
-        services.AddSingleton<IAppVersionService>(new AppVersionService(versionInfo));
-
+        // Add the assembly version
+        services.AddSingleton<IAppVersionService>(new AppVersionService(Assembly.GetExecutingAssembly()?.GetName()?.Version));
 
         services
-            .AddScoped<ApplicationConfigService>()
-        ;
+            .AddScoped<ApplicationConfigService>();
 
         services
             .AddDbContext<SaasKitContext>(options => options.UseSqlServer(this.Configuration.GetConnectionString("DefaultConnection")));

--- a/src/CustomerSite/Startup.cs
+++ b/src/CustomerSite/Startup.cs
@@ -119,9 +119,8 @@ public class Startup
             .AddSingleton<SaaSApiClientConfiguration>(config)
             .AddSingleton<ValidateJwtToken>();
 
-        // Read the versionInfo and Add to services
-        var versionInfo = FileVersionInfo.GetVersionInfo(Assembly.GetExecutingAssembly().Location);
-        services.AddSingleton<IAppVersionService>(new AppVersionService(versionInfo));
+        // Add the assembly version
+        services.AddSingleton<IAppVersionService>(new AppVersionService(Assembly.GetExecutingAssembly()?.GetName()?.Version));
 
         services
             .AddDbContext<SaasKitContext>(options => options.UseSqlServer(this.Configuration.GetConnectionString("DefaultConnection")));

--- a/src/Services/Contracts/IAppVersionService.cs
+++ b/src/Services/Contracts/IAppVersionService.cs
@@ -8,11 +8,4 @@ namespace Marketplace.SaaS.Accelerator.Services.Services;
 public interface IAppVersionService
 {
     string Version { get; }
-
-    int? ProductMajorPart { get; }
-
-    int? ProductMinorPart { get; }
-
-    int? ProductBuildPart { get; }
-
 }

--- a/src/Services/Services/AppVersionService.cs
+++ b/src/Services/Services/AppVersionService.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+﻿using System;
+using System.Diagnostics;
 using System.Net.Http;
 using System.Text.Json;
 using System.Threading.Tasks;
@@ -13,20 +14,18 @@ public class AppVersionService : IAppVersionService
 
     public string Version { get; }
 
-    public int? ProductMajorPart { get; }
-
-    public int? ProductMinorPart { get; }
-
-    public int? ProductBuildPart { get; }
-
     /// <summary>
     /// Sets the Application Version.
     /// </summary>
-    public AppVersionService(FileVersionInfo version)
+    public AppVersionService(Version version)
     {
-        Version = version.ProductVersion;
-        ProductMajorPart = version.ProductMajorPart;
-        ProductMinorPart = version.ProductMinorPart;
-        ProductBuildPart = version.ProductBuildPart;
+        if (version != null)
+        {
+            Version = $"{version?.Major}.{version?.Minor}.{version?.Build}";
+        }
+        else
+        {
+            Version = "1.0.0";
+        }
     }
 }


### PR DESCRIPTION
This pull request includes changes to the `AppVersionService` implementation across multiple files, simplifying how the application version is handled and removing unnecessary properties. The most important changes include updating the service registration in `Startup.cs` files, removing redundant properties from the `IAppVersionService` interface, and modifying the `AppVersionService` class to use the `Version` class instead of `FileVersionInfo`.

Changes to service registration:

* [`src/AdminSite/Startup.cs`](diffhunk://#diff-891829c1ed2a8bb776c03899e9258f5f38fd6996d11488224791e4cd2e959e1fL144-R148): Updated the `ConfigureServices` method to register `IAppVersionService` using the `Version` class instead of `FileVersionInfo`.
* [`src/CustomerSite/Startup.cs`](diffhunk://#diff-18b8953f78c9f320f8e91acc290d309f8e0cc48a6cfcb4f87c6fa39b5a96bd39L122-R123): Updated the `ConfigureServices` method similarly to the `AdminSite` to use the `Version` class.

Simplification of `IAppVersionService`:

* [`src/Services/Contracts/IAppVersionService.cs`](diffhunk://#diff-a5de093a86eeea72dccf59834a7e350347d30eeaff5f46193fb7e3750ee75f64L11-L17): Removed unnecessary properties `ProductMajorPart`, `ProductMinorPart`, and `ProductBuildPart`.

Modification of `AppVersionService`:

* [`src/Services/Services/AppVersionService.cs`](diffhunk://#diff-ea1b332707c389dfeaaff2162d82094e6d89e8c0f74a00a557a9aa3f0fb32772L16-R29): Changed the constructor to accept a `Version` object and simplified the version string construction. Removed the now redundant properties.

Code cleanup:

* [`src/Services/Services/AppVersionService.cs`](diffhunk://#diff-ea1b332707c389dfeaaff2162d82094e6d89e8c0f74a00a557a9aa3f0fb32772L1-R2): Added missing `using System;` directive.