### PR TITLE
Show the Private offer Id for V1 PO on details page

### DIFF
--- a/src/AdminSite/AdminSite.csproj
+++ b/src/AdminSite/AdminSite.csproj
@@ -28,17 +28,16 @@
 
   <ItemGroup>
 	<PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.0" />
-	<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection.Abstractions" Version="8.0.0" />
-	<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.6" />
-	<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.6">
+	<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection.Abstractions" Version="9.0.3" />
+	<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-	  <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.10.0" />
-	  <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.10.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
+	  <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.13.0" />
+	  <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.13.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.3" />
 	 
   </ItemGroup>
 

--- a/src/AdminSite/Views/Home/SubscriptionDetails.cshtml
+++ b/src/AdminSite/Views/Home/SubscriptionDetails.cshtml
@@ -58,6 +58,13 @@
                             @Html.DisplayFor(model => model.PlanId)
                         </dd>
                         <dt class="col-sm-3 p-2 p10">
+                            @Html.DisplayName("Private Offer ID ")
+                            <span><small>(Only for V1 PO. V2 PO already reflects this in above planId.)</small></span>
+                        </dt>
+                        <dd class="col-sm-9 p-2 p10">
+                            @Html.DisplayFor(model => model.PrivateOfferId)
+                        </dd>
+                        <dt class="col-sm-3 p-2 p10">
                             @Html.DisplayName("Term ")
                         </dt>
                         <dd class="col-sm-9 p-2 p10">

--- a/src/CustomerSite/Controllers/HomeController.cs
+++ b/src/CustomerSite/Controllers/HomeController.cs
@@ -251,8 +251,13 @@ public class HomeController : BaseController
                         this.subscriptionService.AddUpdateAllPlanDetailsForSubscription(subscriptionPlanDetail);
 
                         var currentPlan = this.planRepository.GetById(newSubscription.PlanId);
+
+                        //check if Private offer exists for this subscription by passing planid
+                        var subscriptionPlanDetail2 = await this.apiService.GetAllPlansForSubscriptionAsync(newSubscription.SubscriptionId, newSubscription.PlanId).ConfigureAwait(false);
+                        var privateOfferId = subscriptionPlanDetail2?.FirstOrDefault()?.SourceOffers?.FirstOrDefault()?.externalId;
+
                         var subscriptionData = await this.apiService.GetSubscriptionByIdAsync(newSubscription.SubscriptionId).ConfigureAwait(false);
-                        var subscribeId = this.subscriptionService.AddOrUpdatePartnerSubscriptions(subscriptionData);
+                        var subscribeId = this.subscriptionService.AddOrUpdatePartnerSubscriptions(subscriptionData, privateOfferId);
                         if (subscribeId > 0 && subscriptionData.SaasSubscriptionStatus == SubscriptionStatusEnum.PendingFulfillmentStart)
                         {
                             SubscriptionAuditLogs auditLog = new SubscriptionAuditLogs()

--- a/src/CustomerSite/CustomerSite.csproj
+++ b/src/CustomerSite/CustomerSite.csproj
@@ -28,15 +28,14 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection.Abstractions" Version="8.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.6" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.6">
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection.Abstractions" Version="9.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.1.1" />
-	  <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.10.0" />
-	  <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.10.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.3" />
+	  <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.13.0" />
+	  <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.13.0" />
 	  
   </ItemGroup>
 

--- a/src/DataAccess/DataAccess.csproj
+++ b/src/DataAccess/DataAccess.csproj
@@ -14,11 +14,11 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Azure.Identity" Version="1.11.4" />
-		<PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.1" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.6" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.6" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.6">
+		<PackageReference Include="Azure.Identity" Version="1.13.2" />
+		<PackageReference Include="Microsoft.Data.SqlClient" Version="6.0.1" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.3" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.3" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.3">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/src/DataAccess/Entities/Subscriptions.cs
+++ b/src/DataAccess/Entities/Subscriptions.cs
@@ -36,4 +36,6 @@ public partial class Subscriptions
     public virtual ICollection<MeteredAuditLogs> MeteredAuditLogs { get; set; }
     public virtual ICollection<SubscriptionAuditLogs> SubscriptionAuditLogs { get; set; }
     public virtual ICollection<MeteredPlanSchedulerManagement> MeteredPlanSchedulerManagements { get; set; }
+
+    public Guid? PrivateOfferId { get; set; }
 }

--- a/src/DataAccess/Migrations/20250314060926_AddPrivateOfferIdProperty_v810.Designer.cs
+++ b/src/DataAccess/Migrations/20250314060926_AddPrivateOfferIdProperty_v810.Designer.cs
@@ -4,6 +4,7 @@ using Marketplace.SaaS.Accelerator.DataAccess.Context;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Marketplace.SaaS.Accelerator.DataAccess.Migrations
 {
     [DbContext(typeof(SaasKitContext))]
-    partial class SaasKitContextModelSnapshot : ModelSnapshot
+    [Migration("20250314060926_AddPrivateOfferIdProperty_v810")]
+    partial class AddPrivateOfferIdProperty_v810
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/DataAccess/Migrations/20250314060926_AddPrivateOfferIdProperty_v810.cs
+++ b/src/DataAccess/Migrations/20250314060926_AddPrivateOfferIdProperty_v810.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Marketplace.SaaS.Accelerator.DataAccess.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPrivateOfferIdProperty_v810 : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "PrivateOfferId",
+                table: "Subscriptions",
+                type: "uniqueidentifier",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "PrivateOfferId",
+                table: "Subscriptions");
+        }
+    }
+}

--- a/src/MeteredTriggerJob/MeteredTriggerJob.csproj
+++ b/src/MeteredTriggerJob/MeteredTriggerJob.csproj
@@ -14,9 +14,9 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Services\Services.csproj" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.3" />
   </ItemGroup>
   <ItemGroup>
     <None Update="appsettings.json">

--- a/src/Services.Test/Services.Test.csproj
+++ b/src/Services.Test/Services.Test.csproj
@@ -10,14 +10,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="Moq" Version="4.18.3" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.1.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.1.0" />
-    <PackageReference Include="coverlet.collector" Version="1.2.0">
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.8.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Services/Contracts/IFulfillmentApiService.cs
+++ b/src/Services/Contracts/IFulfillmentApiService.cs
@@ -56,7 +56,7 @@ public interface IFulfillmentApiService
     /// </summary>
     /// <param name="subscriptionId">The subscription identifier.</param>
     /// <returns>Get All Plans For Subscription.</returns>
-    Task<List<PlanDetailResultExtension>> GetAllPlansForSubscriptionAsync(Guid subscriptionId);
+    Task<List<PlanDetailResultExtension>> GetAllPlansForSubscriptionAsync(Guid subscriptionId, string planId=null);
 
     /// <summary>
     /// Activates the subscription.

--- a/src/Services/Helpers/ConversionHelper.cs
+++ b/src/Services/Helpers/ConversionHelper.cs
@@ -13,6 +13,7 @@ namespace Marketplace.SaaS.Accelerator.Services.Helpers;
 using MeteringDimension = Models.MeteringDimension;
 using RecurrentBillingTerm = Models.RecurrentBillingTerm;
 using MeteringedQuantityIncluded = Models.MeteringedQuantityIncluded;
+using SourceOffer = Models.SourceOffer;
 /// <summary>
 /// Conversion Helper.
 /// </summary>
@@ -121,7 +122,8 @@ static class ConversionHelper
             IsPerUserPlan = plan.IsPricePerSeat ?? false,
             IsStopSell = plan.IsStopSell ?? false,
             Market = plan.Market,
-            PlanComponents = getPlanComponentsFromPlan(plan)
+            PlanComponents = getPlanComponentsFromPlan(plan),
+            SourceOffers = plan.SourceOffers != null ? getSourceoffers(plan) : new List<SourceOffer>()
         };
     }
     /// <summary>
@@ -190,5 +192,19 @@ static class ConversionHelper
             SubscriptionId = operation.SubscriptionId?.ToString(), 
             ActionType = operation.Action?.ToString()
         };
+    }
+    /// <summary>
+    /// Extract Source Offers from Plan.
+    /// </summary>
+    /// <param name="plan">The plan model.</param>
+    /// <returns>
+    /// List of SourceOffer.
+    /// </returns>
+    public static List<SourceOffer> getSourceoffers(this Plan plan)
+    {
+        return plan.SourceOffers?.Select(offer => new SourceOffer
+        {
+            externalId = offer.ExternalId
+        }).ToList() ?? new List<SourceOffer>();
     }
 }

--- a/src/Services/Models/PlanDetailResult.cs
+++ b/src/Services/Models/PlanDetailResult.cs
@@ -125,6 +125,16 @@ public class PlanDetailResult : SaaSApiResult
     public  PlanComponents PlanComponents { get; set; }
 
 
+    [JsonPropertyName("sourceOffers")]
+    [DisplayName("sourceOffers")]
+    /// <summary>
+    /// Gets or sets the private offer ids with the plan.
+    /// </summary>
+    /// <value>
+    /// The Private offer Id list.
+    /// </value>
+    public List<SourceOffer> SourceOffers { get; set; }
+
     /// <summary>
     /// Get  IsmeteringSupported associate with the plan.
     /// </summary>

--- a/src/Services/Models/SourceOffer.cs
+++ b/src/Services/Models/SourceOffer.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Text.Json.Serialization;
+
+namespace Marketplace.SaaS.Accelerator.Services.Models;
+
+/// <summary>
+/// Private offers Id.
+/// </summary>
+/// <seealso cref="Microsoft.Marketplace.SaasKit.Models.SaaSApiResult" />
+public class SourceOffer
+{
+
+    [JsonPropertyName("externalId")]
+    [DisplayName("externalId")]
+    /// <summary>
+    /// Gets or Sets externalId
+    /// </summary>
+    public Guid? externalId { get; set; }
+        
+}

--- a/src/Services/Models/SubscriptionResultExtension.cs
+++ b/src/Services/Models/SubscriptionResultExtension.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 
 namespace Marketplace.SaaS.Accelerator.Services.Models;
 
@@ -73,4 +74,10 @@ public class SubscriptionResultExtension : SubscriptionResult
     /// Gets or sets a value indicating if we allow subscription updates on the customer side.
     /// </summary>
     public bool AcceptSubscriptionUpdates { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value Private Offer Id.
+    /// </summary>
+    [DisplayFormat(NullDisplayText = "-")]
+    public Guid? PrivateOfferId { get; set; }
 }

--- a/src/Services/Services.csproj
+++ b/src/Services/Services.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.13.2" />
-    <PackageReference Include="Marketplace.SaaS.Client" Version="2.1.0-beta" />
+    <PackageReference Include="Marketplace.SaaS.Client" Version="2.1.1-beta" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="2.3.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.3" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.69.1" />

--- a/src/Services/Services.csproj
+++ b/src/Services/Services.csproj
@@ -10,14 +10,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.11.4" />
-    <PackageReference Include="Marketplace.SaaS.Client" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="2.1.3" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.61.3" />
+    <PackageReference Include="Azure.Identity" Version="1.13.2" />
+    <PackageReference Include="Marketplace.SaaS.Client" Version="2.1.0-beta" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="2.3.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.3" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.69.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-	<PackageReference Include="System.Drawing.Common" Version="8.0.0" />
-	<PackageReference Include="System.Linq.Async" Version="5.0.0" />
+	<PackageReference Include="System.Drawing.Common" Version="9.0.3" />
+	<PackageReference Include="System.Linq.Async" Version="6.0.1" />
 	  
   </ItemGroup>
 

--- a/src/Services/Services/FulfillmentApiService.cs
+++ b/src/Services/Services/FulfillmentApiService.cs
@@ -163,14 +163,14 @@ public class FulfillmentApiService : BaseApiService, IFulfillmentApiService
     /// Get AllPlans For SubscriptionId.
     /// </returns>
     /// <exception cref="FulfillmentException">Invalid subscription ID.</exception>
-    public async Task<List<PlanDetailResultExtension>> GetAllPlansForSubscriptionAsync(Guid subscriptionId)
+    public async Task<List<PlanDetailResultExtension>> GetAllPlansForSubscriptionAsync(Guid subscriptionId, string planId= null)
     {
         this.Logger?.Info($"Inside GetAllPlansForSubscriptionAsync() of FulfillmentApiService, trying to Get All Plans for {subscriptionId}");
         if (subscriptionId != default)
         {
             try
             {
-                var availablePlans = (await this.marketplaceClient.Fulfillment.ListAvailablePlansAsync(subscriptionId)).Value;
+                var availablePlans = (await this.marketplaceClient.Fulfillment.ListAvailablePlansAsync(subscriptionId, planId)).Value;
                 return availablePlans.Plans.planResults();
             }
             catch (RequestFailedException ex)

--- a/src/Services/Services/SubscriptionService.cs
+++ b/src/Services/Services/SubscriptionService.cs
@@ -49,7 +49,7 @@ public class SubscriptionService
     /// </summary>
     /// <param name="subscriptionDetail">The subscription detail.</param>
     /// <returns>Subscription Id.</returns>
-    public int AddOrUpdatePartnerSubscriptions(SubscriptionResult subscriptionDetail, int customerUserId = 0)
+    public int AddOrUpdatePartnerSubscriptions(SubscriptionResult subscriptionDetail, Guid? privateOfferId, int customerUserId = 0)
     {
         var isActive = this.IsSubscriptionDeleted(Convert.ToString(subscriptionDetail.SaasSubscriptionStatus));
         Subscriptions newSubscription = new Subscriptions()
@@ -70,7 +70,8 @@ public class SubscriptionService
             AmpOfferId = subscriptionDetail.OfferId,
             Term = subscriptionDetail.Term.TermUnit.ToString(),
             StartDate = subscriptionDetail.Term.StartDate.ToUniversalTime().DateTime,
-            EndDate = subscriptionDetail.Term.EndDate.ToUniversalTime().DateTime
+            EndDate = subscriptionDetail.Term.EndDate.ToUniversalTime().DateTime,
+            PrivateOfferId = privateOfferId
         };
         return this.subscriptionRepository.Save(newSubscription);
     }
@@ -180,6 +181,7 @@ public class SubscriptionService
         subscritpionDetail.Purchaser = new PurchaserResult();
         subscritpionDetail.Purchaser.EmailId = subscription.PurchaserEmail;
         subscritpionDetail.Purchaser.TenantId = subscription.PurchaserTenantId ?? default;
+        subscritpionDetail.PrivateOfferId = subscription.PrivateOfferId;
         return subscritpionDetail;
     }
 

--- a/src/UI.Test/UI.Test.csproj
+++ b/src/UI.Test/UI.Test.csproj
@@ -18,16 +18,19 @@
   </ItemGroup>
 
   <ItemGroup>
-	  <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
-	  <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.4" />
-	  <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />
-	  <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
-	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-	  <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
-	  <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
-	  <PackageReference Include="coverlet.collector" Version="6.0.0" />
-	  <PackageReference Include="Selenium.WebDriver" Version="4.16.2" />
-	  <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="124.0.6367.7800" />
+	  <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.3" />
+	  <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.3" />
+	  <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.3" />
+	  <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.3" />
+	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+	  <PackageReference Include="MSTest.TestAdapter" Version="3.8.2" />
+	  <PackageReference Include="MSTest.TestFramework" Version="3.8.2" />
+	  <PackageReference Include="coverlet.collector" Version="6.0.4">
+	    <PrivateAssets>all</PrivateAssets>
+	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+	  </PackageReference>
+	  <PackageReference Include="Selenium.WebDriver" Version="4.29.0" />
+	  <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="134.0.6998.8800" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This pull request includes several updates to package dependencies, the addition of a new `PrivateOfferId` property, and associated changes to controllers and views. The most important changes include updating package references, adding support for `PrivateOfferId` in subscriptions, and modifying the database schema to include the new property.

### Package Dependency Updates:
* Updated various package references in `AdminSite.csproj`, `CustomerSite.csproj`, and `DataAccess.csproj` to newer versions. [[1]](diffhunk://#diff-1fac88d2f85aa0610e3d1874c53d052c629f7a8d4afd39f8cf93361ac54b74a2L31-R40) [[2]](diffhunk://#diff-b6e4c832c9cdd357ba44d5e9bd9669ce423d26b5eac721ccefe460eca1ed860dL31-R38) [[3]](diffhunk://#diff-56ab054e4383b79e561e91c51fe0133d7620adceeefd2ccd9d5c5a274f7911f3L17-R21)

### Private Offer ID Support:
* Added `PrivateOfferId` property to the `Subscriptions` entity in `Entities/Subscriptions.cs`.
* Updated `HomeController.cs` to handle `PrivateOfferId` when adding or updating subscriptions. [[1]](diffhunk://#diff-a2031064fb3d426afe121f1370b7bac5152672df79f2d7d965c27630298eb7e3L942-R953) [[2]](diffhunk://#diff-e5f87e8974653aeea117ca626e452603f570d44fa2dc77f7666a21abd2e2c83dR254-R260)
* Modified `SubscriptionDetails.cshtml` to display the `PrivateOfferId`.

### Database Schema Changes:
* Added a migration to include the `PrivateOfferId` column in the `Subscriptions` table.
* Updated `SaasKitContextModelSnapshot.cs` to reflect the new database schema changes. 