### PR TITLE
Updated to support 4y and 5y terms

### DIFF
--- a/src/AdminSite/AdminSite.csproj
+++ b/src/AdminSite/AdminSite.csproj
@@ -35,8 +35,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-	  <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.10.0" />
-	  <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.10.0" />
+	  <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.14.0" />
+	  <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
 	 

--- a/src/CustomerSite/CustomerSite.csproj
+++ b/src/CustomerSite/CustomerSite.csproj
@@ -35,8 +35,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.1.1" />
-	  <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.10.0" />
-	  <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.10.0" />
+	  <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.14.0" />
+	  <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
 	  
   </ItemGroup>
 

--- a/src/Services/Models/TermUnitEnum.cs
+++ b/src/Services/Models/TermUnitEnum.cs
@@ -16,14 +16,24 @@ public enum TermUnitEnum
     /// The Yearly.
     /// </summary>
     P1Y,
-        
+
     /// <summary>
-    /// The Yearly.
+    /// Two Year term.
     /// </summary>
     P2Y,
-        
+
     /// <summary>
-    /// The Yearly.
+    /// Three Year term.
     /// </summary>
     P3Y,
+
+    /// <summary>
+    /// Four Year term.
+    /// </summary>
+    P4Y,
+
+    /// <summary>
+    /// Five Year term.
+    /// </summary>
+    P5Y,
 }

--- a/src/Services/Services.csproj
+++ b/src/Services/Services.csproj
@@ -10,11 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.11.4" />
-    <PackageReference Include="Marketplace.SaaS.Client" Version="2.0.0" />
+    <PackageReference Include="Marketplace.SaaS.Client" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="2.1.3" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.61.3" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 	<PackageReference Include="System.Drawing.Common" Version="8.0.0" />
 	<PackageReference Include="System.Linq.Async" Version="5.0.0" />


### PR DESCRIPTION
This pull request includes updates to package dependencies across multiple projects and enhancements to the `TermUnitEnum` enum. The primary focus is on upgrading package versions for consistency and adding new term options to the enum.

### Dependency Updates:
* [`src/AdminSite/AdminSite.csproj`](diffhunk://#diff-1fac88d2f85aa0610e3d1874c53d052c629f7a8d4afd39f8cf93361ac54b74a2L38-R39): Upgraded `Microsoft.CodeAnalysis.Common` and `Microsoft.CodeAnalysis.CSharp` from version `4.10.0` to `4.14.0` for improved compiler features and bug fixes.
* [`src/CustomerSite/CustomerSite.csproj`](diffhunk://#diff-b6e4c832c9cdd357ba44d5e9bd9669ce423d26b5eac721ccefe460eca1ed860dL38-R39): Upgraded `Microsoft.CodeAnalysis.Common` and `Microsoft.CodeAnalysis.CSharp` from version `4.10.0` to `4.14.0` to align with the AdminSite project.
* [`src/Services/Services.csproj`](diffhunk://#diff-b6d207e436774ceb79269386cf210b961bc8f7f0f1a74cbdcd4535e10b7bfe6aL13-L17): Updated `Marketplace.SaaS.Client` from version `2.0.0` to `2.2.0` for new features and removed unused dependencies `Azure.Identity` and `Microsoft.Identity.Client`.

### Enum Enhancements:
* [`src/Services/Models/TermUnitEnum.cs`](diffhunk://#diff-9d2e80743c325301fa00752b6b0c0a43efe33c4658c1b3adf6b35efa950e2441L21-R38): Added new options `P4Y` and `P5Y` to represent four-year and five-year terms, respectively, and updated the documentation for existing terms to clarify their descriptions.