### PR TITLE
Update README.md to add note for 4y and 5y

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ If you need help with the accelerator or would like to report defects or feature
 
 ---
 
+
+> **Note:** SaaS subscription purchases for the new 4-year and 5-year terms are only supported in version **8.1.0** or later.  
+> Please upgrade your instance if you have deals using these terms.
+
 # Microsoft Commercial Marketplace - Community Code for SaaS Applications
 
 <!-- no toc -->


### PR DESCRIPTION
This pull request updates the `README.md` file to include a note about SaaS subscription purchases. The change informs users about the version requirement for new subscription terms.

Documentation update:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R8-R11): Added a note specifying that SaaS subscription purchases for 4-year and 5-year terms are supported only in version **8.1.0** or later, advising users to upgrade their instance if they have deals using these terms.