### PR TITLE
Updated script to use connection string to run sql db commands

### DIFF
--- a/deployment/Deploy.ps1
+++ b/deployment/Deploy.ps1
@@ -572,15 +572,16 @@ Write-host "📜 Deploy Code"
 
 Write-host "   🔵 Deploy Database"
 Write-host "      ➡️ Generate SQL schema/data script"
-Set-Content -Path ../src/AdminSite/appsettings.Development.json -value "{`"ConnectionStrings`": {`"DefaultConnection`":`"$Connection`"}}"
+$ConnectionString="Server=tcp:"+$ServerUri+";Database="+$SQLDatabaseName+";TrustServerCertificate=True;Authentication=Active Directory Default;"
+Set-Content -Path ../src/AdminSite/appsettings.Development.json -value "{`"ConnectionStrings`": {`"DefaultConnection`":`"$ConnectionString`"}}"
 dotnet-ef migrations script  --output script.sql --idempotent --context SaaSKitContext --project ../src/DataAccess/DataAccess.csproj --startup-project ../src/AdminSite/AdminSite.csproj
 Write-host "      ➡️ Execute SQL schema/data script"
 $dbaccesstoken = (Get-AzAccessToken -ResourceUrl https://database.windows.net).Token
-Invoke-Sqlcmd -InputFile ./script.sql -ServerInstance $ServerUri -database $SQLDatabaseName -AccessToken $dbaccesstoken
+Invoke-Sqlcmd -InputFile ./script.sql -ConnectionString $ConnectionString
 
 Write-host "      ➡️ Execute SQL script to Add WebApps"
 $AddAppsIdsToDB = "CREATE USER [$WebAppNameAdmin] FROM EXTERNAL PROVIDER;ALTER ROLE db_datareader ADD MEMBER  [$WebAppNameAdmin];ALTER ROLE db_datawriter ADD MEMBER  [$WebAppNameAdmin]; GRANT EXEC TO [$WebAppNameAdmin]; CREATE USER [$WebAppNamePortal] FROM EXTERNAL PROVIDER;ALTER ROLE db_datareader ADD MEMBER [$WebAppNamePortal];ALTER ROLE db_datawriter ADD MEMBER [$WebAppNamePortal]; GRANT EXEC TO [$WebAppNamePortal];"
-Invoke-Sqlcmd -Query $AddAppsIdsToDB -ServerInstance $ServerUri -database $SQLDatabaseName -AccessToken $dbaccesstoken
+Invoke-Sqlcmd -Query $AddAppsIdsToDB -ConnectionString $ConnectionString
 
 Write-host "   🔵 Deploy Code to Admin Portal"
 az webapp deploy --resource-group $ResourceGroupForDeployment --name $WebAppNameAdmin --src-path "../Publish/AdminSite.zip" --type zip --output $azCliOutput

--- a/deployment/Deploy.ps1
+++ b/deployment/Deploy.ps1
@@ -572,11 +572,10 @@ Write-host "📜 Deploy Code"
 
 Write-host "   🔵 Deploy Database"
 Write-host "      ➡️ Generate SQL schema/data script"
-$ConnectionString="Server=tcp:"+$ServerUri+";Database="+$SQLDatabaseName+";TrustServerCertificate=True;Authentication=Active Directory Default;"
+$ConnectionString="Server=tcp:"+$ServerUri+";Database="+$SQLDatabaseName+";Authentication=Active Directory Default;"
 Set-Content -Path ../src/AdminSite/appsettings.Development.json -value "{`"ConnectionStrings`": {`"DefaultConnection`":`"$ConnectionString`"}}"
 dotnet-ef migrations script  --output script.sql --idempotent --context SaaSKitContext --project ../src/DataAccess/DataAccess.csproj --startup-project ../src/AdminSite/AdminSite.csproj
 Write-host "      ➡️ Execute SQL schema/data script"
-$dbaccesstoken = (Get-AzAccessToken -ResourceUrl https://database.windows.net).Token
 Invoke-Sqlcmd -InputFile ./script.sql -ConnectionString $ConnectionString
 
 Write-host "      ➡️ Execute SQL script to Add WebApps"


### PR DESCRIPTION
This pull request updates the `Deploy.ps1` script to enhance database deployment by switching from server instance-based authentication to connection string-based authentication. This change simplifies the configuration and improves security by leveraging Active Directory Default authentication.

### Database Deployment Enhancements:

* Updated the `ConnectionString` variable to use Active Directory Default authentication, including `TrustServerCertificate=True`, and replaced the previous server instance-based approach. (`[deployment/Deploy.ps1L575-R584](diffhunk://#diff-945908cece7ba32245d369c8e39d64bc1d6c4bd58abf5a9db9829e0c1ab23449L575-R584)`)
* Modified all `Invoke-Sqlcmd` commands to use the new `ConnectionString` variable instead of `ServerInstance` and `AccessToken`. (`[deployment/Deploy.ps1L575-R584](diffhunk://#diff-945908cece7ba32245d369c8e39d64bc1d6c4bd58abf5a9db9829e0c1ab23449L575-R584)`)