### PR TITLE
fix(CustomerSite): remove hardcoded HTTPS UseUrls that breaks Kestrel-as-edge hosting (fixes #789)

### DIFF
--- a/src/CustomerSite/Program.cs
+++ b/src/CustomerSite/Program.cs
@@ -42,7 +42,7 @@ public class Program
             })
             .ConfigureWebHostDefaults(webBuilder =>
             {
-                webBuilder.UseUrls("https://*:5001", "http://*:5000");
+                //webBuilder.UseUrls("https://*:5001", "http://*:5000");
                 webBuilder.UseStartup<Startup>();
             });
 }


### PR DESCRIPTION
Fixes #789.

`CustomerSite` hardcodes an HTTPS listening URL that Kestrel cannot satisfy, so the site fails to start on any hosting model where Kestrel is the edge server (Linux App Service, containers):

```
System.InvalidOperationException: Unable to configure HTTPS endpoint.
No server certificate was specified, and the default developer certificate
could not be found or is out of date.
```

## The change

```diff
- webBuilder.UseUrls("https://*:5001", "http://*:5000");
+ //webBuilder.UseUrls("https://*:5001", "http://*:5000");
```

This mirrors `src/AdminSite/Program.cs` line 45, where the equivalent call is **already commented out** — which is precisely why the admin site starts on Linux App Service today and the customer site does not.

## Why this is safe

- **Local development is unaffected.** `CustomerSite/Properties/launchSettings.json` already sets `"applicationUrl": "https://localhost:5001;http://localhost:5000"` — the same two URLs. The `UseUrls` call is redundant.
- **Windows App Service is unaffected.** The ASP.NET Core Module supplies the listening URLs there, so `UseUrls` was already being ignored.
- **Linux App Service and containers are fixed.** Kestrel falls back to the host-provided configuration (`ASPNETCORE_URLS` / the App Service `PORT`), binds HTTP only, and lets TLS terminate at the front end, as it should.

## Why `ASPNETCORE_URLS` was not a viable workaround

`UseUrls()` is applied after host configuration is read and overrides the environment variable, so no app setting could correct this from the outside. This is also why #789 reproduced even after `Startup.cs` was stripped almost bare — the failure occurs while the host is being built, before any `Startup` code runs.

Verified against 8.2.1.
