### PR TITLE
Upgrade solution from .NET 8 to .NET 10 (LTS)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ env:
   CUSTOMER_PROJECT: './src/CustomerSite/CustomerSite.csproj'
   PUBLISHER_PROJECT: './src/AdminSite/AdminSite.csproj'
   SERVICES_TEST_PROJECT: './src/Services.Test/Services.Test.csproj'
-  DOTNET_CORE_VERSION: '8.0.303'
+  DOTNET_CORE_VERSION: '10.0.400'
   
 jobs:
   BuildApps:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -29,7 +29,7 @@ env:
   CUSTOMER_AZURE_WEBAPP_PACKAGE_PATH: './src/Marketplace.SaaS.Accelerator.CustomerSite/publish'
   PUBLISHER_AZURE_WEBAPP_PACKAGE_PATH: './src/Marketplace.SaaS.Accelerator.AdminSite/publish'
   SQLSCRIPT_PATH: './src/Marketplace.SaaS.Accelerator.AdminSite/publish'
-  DOTNET_CORE_VERSION: '8.0.303'
+  DOTNET_CORE_VERSION: '10.0.400'
   
 jobs:
   deployandtest:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -54,7 +54,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 10.0.x
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/deployment/Deploy.ps1
+++ b/deployment/Deploy.ps1
@@ -195,12 +195,12 @@ if(!($KeyVault -match "^[a-zA-Z][a-z0-9-]+$")) {
 
 #region pre-checks
 
-# check if dotnet 8 is installed
+# check if dotnet 10 is installed
 
 $dotnetversion = dotnet --version
 
-if(!$dotnetversion.StartsWith('8.')) {
-    Throw "🛑 Dotnet 8 not installed. Install dotnet8 and re-run the script."
+if(!$dotnetversion.StartsWith('10.')) {
+    Throw "🛑 Dotnet 10 not installed. Install dotnet10 and re-run the script."
     Exit
 }
 
@@ -543,7 +543,7 @@ az appservice plan create -g $ResourceGroupForDeployment -n $WebAppNameService -
 
 Write-host "   🔵 Admin Portal WebApp"
 Write-host "      ➡️ Create Web App"
-az webapp create -g $ResourceGroupForDeployment -p $WebAppNameService -n $WebAppNameAdmin  --runtime dotnet:8 --output $azCliOutput
+az webapp create -g $ResourceGroupForDeployment -p $WebAppNameService -n $WebAppNameAdmin  --runtime dotnet:10 --output $azCliOutput
 Write-host "      ➡️ Assign Identity"
 $WebAppNameAdminId = az webapp identity assign -g $ResourceGroupForDeployment  -n $WebAppNameAdmin --identities [system] --query principalId -o tsv
 Write-host "      ➡️ Setup access to KeyVault"
@@ -555,7 +555,7 @@ az webapp config set -g $ResourceGroupForDeployment -n $WebAppNameAdmin --always
 
 Write-host "   🔵 Customer Portal WebApp"
 Write-host "      ➡️ Create Web App"
-az webapp create -g $ResourceGroupForDeployment -p $WebAppNameService -n $WebAppNamePortal --runtime dotnet:8 --output $azCliOutput
+az webapp create -g $ResourceGroupForDeployment -p $WebAppNameService -n $WebAppNamePortal --runtime dotnet:10 --output $azCliOutput
 Write-host "      ➡️ Assign Identity"
 $WebAppNamePortalId= az webapp identity assign -g $ResourceGroupForDeployment  -n $WebAppNamePortal --identities [system] --query principalId -o tsv 
 Write-host "      ➡️ Setup access to KeyVault"

--- a/docs/Installation-Instructions.md
+++ b/docs/Installation-Instructions.md
@@ -36,9 +36,9 @@ Copy the following section to an editor and update it to match your company pref
 ``` powershell
 wget https://dot.net/v1/dotnet-install.sh -O dotnet-install.sh; `
 chmod +x dotnet-install.sh; `
-./dotnet-install.sh -version 8.0.303; `
+./dotnet-install.sh -version 10.0.400; `
 $ENV:PATH="$HOME/.dotnet:$ENV:PATH"; `
-dotnet tool install --global dotnet-ef --version 8.0.0; `
+dotnet tool install --global dotnet-ef --version 10.0.11; `
 git clone https://github.com/Azure/Commercial-Marketplace-SaaS-Accelerator.git -b 8.2.1 --depth 1; `
 cd ./Commercial-Marketplace-SaaS-Accelerator/deployment; `
 .\Deploy.ps1 `
@@ -83,9 +83,9 @@ If you already have deployed the SaaS Accelerator, but you want to update it so 
 ``` powershell
 wget https://dot.net/v1/dotnet-install.sh -O dotnet-install.sh; `
 chmod +x dotnet-install.sh; `
-./dotnet-install.sh -version 8.0.303; `
+./dotnet-install.sh -version 10.0.400; `
 $ENV:PATH="$HOME/.dotnet:$ENV:PATH"; `
-dotnet tool install --global dotnet-ef --version 8.0.0; `
+dotnet tool install --global dotnet-ef --version 10.0.11; `
 git clone https://github.com/Azure/Commercial-Marketplace-SaaS-Accelerator.git -b <release-version-branch-to-deploy> --depth 1; `
 cd ./Commercial-Marketplace-SaaS-Accelerator/deployment; `
 .\Upgrade.ps1 `

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.303",
+    "version": "10.0.400",
     "rollForward": "latestFeature"
   }
 }

--- a/src/AdminSite/AdminSite.csproj
+++ b/src/AdminSite/AdminSite.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-	  <TargetFramework>net8.0</TargetFramework>
+	  <TargetFramework>net10.0</TargetFramework>
 	  <Authors>Microsoft.Marketplace</Authors>
 	  <Company>Microsoft</Company>
 	  <Product>Marketplace.SaaS.Accelerator</Product>
@@ -27,18 +27,12 @@
   </ItemGroup>
 
   <ItemGroup>
-	<PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.0" />
-	<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection.Abstractions" Version="8.0.0" />
-	<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.6" />
-	<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.6">
+	<PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.11" />
+	<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.11" />
+	<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.11">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-	  <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.14.0" />
-	  <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
 	 
   </ItemGroup>
 

--- a/src/CustomerSite/CustomerSite.csproj
+++ b/src/CustomerSite/CustomerSite.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-	  <TargetFramework>net8.0</TargetFramework>
+	  <TargetFramework>net10.0</TargetFramework>
 	  <Authors>Microsoft.Marketplace</Authors>
 	  <Company>Microsoft</Company>
 	  <Product>Marketplace.SaaS.Accelerator</Product>
@@ -27,16 +27,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection.Abstractions" Version="8.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.6" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.6">
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.11" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.11" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.11">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.1.1" />
-	  <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.14.0" />
-	  <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
 	  
   </ItemGroup>
 

--- a/src/DataAccess/DataAccess.csproj
+++ b/src/DataAccess/DataAccess.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<Authors>Microsoft.Marketplace</Authors>
 		<Company>Microsoft</Company>
 		<Product>Marketplace.SaaS.Accelerator</Product>
@@ -14,11 +14,10 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Azure.Identity" Version="1.11.4" />
-		<PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.1" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.6" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.6" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.6">
+		<PackageReference Include="Azure.Identity" Version="1.21.0" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.11" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.11" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.11">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/src/MeteredTriggerJob/MeteredTriggerJob.csproj
+++ b/src/MeteredTriggerJob/MeteredTriggerJob.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk;Microsoft.NET.Sdk.Publish">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Authors>Microsoft.Marketplace</Authors>
     <Company>Microsoft</Company>
     <Product>Marketplace.SaaS.Accelerator</Product>
@@ -14,9 +14,9 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Services\Services.csproj" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.11" />
   </ItemGroup>
   <ItemGroup>
     <None Update="appsettings.json">

--- a/src/Services.Test/Services.Test.csproj
+++ b/src/Services.Test/Services.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	  <TargetFramework>net8.0</TargetFramework>
+	  <TargetFramework>net10.0</TargetFramework>
 	  <Authors>Microsoft.Marketplace</Authors>
 	  <Company>Microsoft</Company>
 	  <Product>Marketplace.SaaS.Accelerator</Product>
@@ -10,14 +10,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="Moq" Version="4.18.3" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.1.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.1.0" />
-    <PackageReference Include="coverlet.collector" Version="1.2.0">
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.11" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.11.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.11.1" />
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Services/Services.csproj
+++ b/src/Services/Services.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	  <TargetFramework>net8.0</TargetFramework>
+	  <TargetFramework>net10.0</TargetFramework>
 	  <Authors>Microsoft.Marketplace</Authors>
 	  <Company>Microsoft</Company>
 	  <Product>Marketplace.SaaS.Accelerator</Product>
@@ -10,12 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Marketplace.SaaS.Client" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="2.1.3" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-	<PackageReference Include="System.Drawing.Common" Version="8.0.0" />
-	<PackageReference Include="System.Linq.Async" Version="5.0.0" />
+	<PackageReference Include="System.Drawing.Common" Version="10.0.11" />
 	  
   </ItemGroup>
 

--- a/src/UI.Test/UI.Test.csproj
+++ b/src/UI.Test/UI.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
 	<Authors>Microsoft.Marketplace</Authors>
 	<Company>Microsoft</Company>
@@ -18,14 +18,14 @@
   </ItemGroup>
 
   <ItemGroup>
-	  <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
-	  <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.4" />
-	  <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />
-	  <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
-	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-	  <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
-	  <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
-	  <PackageReference Include="coverlet.collector" Version="6.0.0" />
+	  <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.11" />
+	  <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.11" />
+	  <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.11" />
+	  <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.11" />
+	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+	  <PackageReference Include="MSTest.TestAdapter" Version="3.11.1" />
+	  <PackageReference Include="MSTest.TestFramework" Version="3.11.1" />
+	  <PackageReference Include="coverlet.collector" Version="10.0.1" />
 	  <PackageReference Include="Selenium.WebDriver" Version="4.16.2" />
 	  <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="124.0.6367.7800" />
   </ItemGroup>


### PR DESCRIPTION
## Summary

Upgrades the solution from **.NET 8** to **.NET 10 (LTS)**.

.NET 8 reaches end of support on **November 10, 2026**. .NET 10 is the current LTS release, supported through **November 2028**.

This is a mechanical framework/package upgrade. **No application logic was changed — zero `.cs` files are modified in this PR.**

## Changes

**Target framework** — `net8.0` → `net10.0` across all 7 projects, and `global.json` SDK pin `8.0.303` → `10.0.400`.

**Package updates**
- EF Core / SqlServer / Design / Tools → `10.0.11`
- `Microsoft.AspNetCore.Authentication.OpenIdConnect` → `10.0.11`
- `System.Drawing.Common`, `Microsoft.Extensions.Configuration.*` → `10.0.11`
- `Azure.Identity` `1.11.4` → `1.21.0`
- Test stack: MSTest `2.1.0`/`3.1.1` → `3.11.1`, Test SDK `16.5.0`/`17.x` → `18.9.0`, Moq → `4.20.72`, coverlet → `10.0.1`

**Package removals** (these are now provided by the shared framework; keeping them triggers `NU1510`)
- `Microsoft.Bcl.AsyncInterfaces`, `Microsoft.AspNetCore.DataProtection.Abstractions`, `Microsoft.Extensions.Logging`, `Microsoft.Extensions.Logging.Debug`, `Microsoft.Extensions.Logging.Console`

**Notable fixes**
- `Services.csproj`: replaced `Microsoft.AspNetCore.Mvc.ViewFeatures 2.1.3` (an ASP.NET Core 2.1-era package referenced from a non-web library) with `<FrameworkReference Include="Microsoft.AspNetCore.App" />`. This was the highest-risk item in the upgrade and resolved cleanly.
- Removed `System.Linq.Async 5.0.0`, which collides with .NET 10's in-box `System.Linq.AsyncEnumerable` (`CS0121`). Confirmed **zero usages** in the codebase.
- Removed the obsolete `Microsoft.CodeAnalysis.*` version pins. These existed only to force up the old Roslyn that EF Core 8's Design package pulled in; EF Core 10 brings Roslyn 5.0.0 natively. **This clears all 12 pre-existing `NU1608` warnings.**
- Dropped the explicit `Microsoft.Data.SqlClient 5.2.1` pin so EF Core 10 resolves its tested `6.1.6`, rather than forcing an untested combination.

**CI / docs**
- `ci.yml`, `cicd.yml`: `DOTNET_CORE_VERSION` → `10.0.400`; `codeql-analysis.yml` → `10.0.x`
- `Deploy.ps1`: prerequisite version guard and both `--runtime dotnet:10` publish targets
- `docs/Installation-Instructions.md`: `dotnet-install` and `dotnet-ef` versions

## Validation

**Build & tests**
- Clean-from-scratch Release and Debug builds: **0 errors** (down from 12 `NU1608` warnings on `main`)
- `Services.Test`: 2/2 passing; `UI.Test` compiles
- All 3 `Deploy.ps1` publish steps succeed, including the self-contained `win-x64` WebJob

**Database (EF Core 10)**
- Migration script generated and applied successfully: 27 tables, 4 stored procedures, `ProductVersion 10.0.11`
- `dotnet ef migrations has-pending-model-changes` → no model drift
- **All 4 `FromSqlRaw` stored-procedure call sites were exercised at runtime and pass** (`spGetFormattedEmailBody`, `spGetOfferParameters`, `spGetPlanEvents`, `spGetSubscriptionParameters`). This was the primary runtime risk of the EF Core 8 → 10 jump.

**Azure App Service**
- Deployed both sites to App Service; they provision as `netFrameworkVersion v10.0`
- Runtime confirms clean startup: `Application 'C:\home\site\wwwroot\' started successfully`

## Notes for reviewers

- MSTest was deliberately kept on **3.11.1** rather than 4.x to limit blast radius. The 3.11 analyzer emits 2 advisory `MSTEST0005` warnings against the pre-existing `TestContext` backing-field pattern in `UI.Test`; these are cosmetic and were left unaddressed to keep this diff free of `.cs` changes.
- The `Version` property in `AdminSite.csproj` / `CustomerSite.csproj` is still `8.2.1` and was intentionally left untouched — it may want bumping as part of a release.
- Selenium UI tests were not run (they require a fully configured live deployment).
