### PR TITLE
Fix retired AzureRM cmdlet blocking deployment in Deploy.ps1

### DIFF
--- a/deployment/Deploy.ps1
+++ b/deployment/Deploy.ps1
@@ -211,7 +211,7 @@ Write-Host "Starting SaaS Accelerator Deployment..."
 
 
 #region Check If SQL Server Exist
-$sql_exists = Get-AzureRmSqlServer -ServerName $SQLServerName -ResourceGroupName $ResourceGroupForDeployment -ErrorAction SilentlyContinue
+$sql_exists = Get-AzSqlServer -ServerName $SQLServerName -ResourceGroupName $ResourceGroupForDeployment -ErrorAction SilentlyContinue
 if ($sql_exists) 
 {
 	Write-Host ""


### PR DESCRIPTION
## Summary

`Deploy.ps1` calls **`Get-AzureRmSqlServer`** when checking whether the SQL server already exists. The AzureRM PowerShell module was **retired in February 2024** and cannot be installed on current PowerShell versions, so this cmdlet is unavailable in any modern environment.

This replaces it with the Az module equivalent, **`Get-AzSqlServer`** (same parameters, same return shape).

## Impact

On a current machine the existing call fails with `The term 'Get-AzureRmSqlServer' is not recognized`. Because the script sets `$ErrorActionPreference = "Stop"`, this aborts the deployment at the SQL server check — before any application code or database schema is deployed.

This is a **pre-existing bug unrelated to any particular .NET version**; it blocks deployment on the current `main` branch.

## Change

```diff
-$sql_exists = Get-AzureRmSqlServer -ServerName $SQLServerName -ResourceGroupName $ResourceGroupForDeployment -ErrorAction SilentlyContinue
+$sql_exists = Get-AzSqlServer -ServerName $SQLServerName -ResourceGroupName $ResourceGroupForDeployment -ErrorAction SilentlyContinue
```

One line, in `deployment/Deploy.ps1`.

## Validation

Verified by running `Deploy.ps1` end to end against a live Azure subscription. With this fix the SQL server existence check completes correctly and the script proceeds to provision the resource group, SQL server, database, App Service plan, and both web apps.

## How this was found

Discovered while validating a separate .NET 10 upgrade by performing a real Azure deployment. Submitting it independently since it stands on its own and is not related to that upgrade.

## Note

The script also depends on `Invoke-Sqlcmd` (from the `SqlServer` module), which is not currently listed in the prerequisites. That is left out of this PR to keep the change focused, but may be worth documenting separately.
