### PR TITLE
Update install docs to reference the 10.0.0 release tag

### DIFF
--- a/docs/Advanced-Instructions.md
+++ b/docs/Advanced-Instructions.md
@@ -38,7 +38,7 @@ Please note: the SaaS Accelerator is community-supported. If you need help or ha
    1. Copy the following section to an editor and update it to match your company preference. Replace SOME-UNIQUE-STRING with your Team name or some other random string.
 ``` powershell
 dotnet tool install --global dotnet-ef; `
-git clone https://github.com/Azure/Commercial-Marketplace-SaaS-Accelerator.git -b 7.6.2 --depth 1; `
+git clone https://github.com/Azure/Commercial-Marketplace-SaaS-Accelerator.git -b 10.0.0 --depth 1; `
 cd ./Commercial-Marketplace-SaaS-Accelerator/deployment; `
 .\Deploy.ps1 `
  -WebAppNamePrefix "marketplace-SOME-UNIQUE-STRING" `

--- a/docs/Advanced-Instructions.md
+++ b/docs/Advanced-Instructions.md
@@ -37,7 +37,11 @@ Please note: the SaaS Accelerator is community-supported. If you need help or ha
    
    1. Copy the following section to an editor and update it to match your company preference. Replace SOME-UNIQUE-STRING with your Team name or some other random string.
 ``` powershell
-dotnet tool install --global dotnet-ef; `
+wget https://dot.net/v1/dotnet-install.sh -O dotnet-install.sh; `
+chmod +x dotnet-install.sh; `
+./dotnet-install.sh -version 10.0.400; `
+$ENV:PATH="$HOME/.dotnet:$ENV:PATH"; `
+dotnet tool install --global dotnet-ef --version 10.0.11; `
 git clone https://github.com/Azure/Commercial-Marketplace-SaaS-Accelerator.git -b 10.0.0 --depth 1; `
 cd ./Commercial-Marketplace-SaaS-Accelerator/deployment; `
 .\Deploy.ps1 `

--- a/docs/Installation-Instructions.md
+++ b/docs/Installation-Instructions.md
@@ -39,7 +39,7 @@ chmod +x dotnet-install.sh; `
 ./dotnet-install.sh -version 10.0.400; `
 $ENV:PATH="$HOME/.dotnet:$ENV:PATH"; `
 dotnet tool install --global dotnet-ef --version 10.0.11; `
-git clone https://github.com/Azure/Commercial-Marketplace-SaaS-Accelerator.git -b 8.2.1 --depth 1; `
+git clone https://github.com/Azure/Commercial-Marketplace-SaaS-Accelerator.git -b 10.0.0 --depth 1; `
 cd ./Commercial-Marketplace-SaaS-Accelerator/deployment; `
 .\Deploy.ps1 `
  -WebAppNamePrefix "SOME-UNIQUE-STRING" `


### PR DESCRIPTION
Following the install instructions currently gives you the previously tagged release rather than current `main`, because the release tag is hardcoded in the `git clone` command.

| File | Was | Now |
|---|---|---|
| `docs/Installation-Instructions.md` | `-b 8.2.1` | `-b 10.0.0` |
| `docs/Advanced-Instructions.md` | `-b 7.6.2` | `-b 10.0.0` |

`Advanced-Instructions.md` had drifted two majors behind, so that path has been handing out 7.6.2 for a while.

These are the only two hardcoded version references in the repo - `Deploy.ps1`, `Upgrade.ps1`, `README.md` and the appsettings contain none. Both `AdminSite.csproj` and `CustomerSite.csproj` already declare `10.0.0`.

**The 10.0.0 tag needs to be created on the commit that merges this PR.** Tagging any earlier commit means `git clone -b 10.0.0` still delivers docs that tell you to clone 8.2.1.

Two notes for whoever cuts the release:

- Suggest tagging `10.0.0` rather than `10.0`. `AdminSite` checks for updates by calling `releases/latest` and comparing `tag_name` against `AppVersionService.Version`, which formats as `Major.Minor.Build` (`10.0.0`). A two-part tag still compares correctly, but three parts matches both the csproj and all existing tags.
- Publishing this release will start showing the *"A New SaaS Accelerator version is available!"* banner on existing 8.2.1 installations, via that same check in `HomeController.Index`.