### PR TITLE
Put the .NET global tools folder on PATH and fail fast without dotnet-ef

### DIFF
--- a/deployment/Deploy.ps1
+++ b/deployment/Deploy.ps1
@@ -210,6 +210,20 @@ if(!$dotnetversion.StartsWith('10.')) {
     Exit
 }
 
+# check if dotnet-ef is installed and on the PATH
+
+if(!(Get-Command dotnet-ef -ErrorAction SilentlyContinue)) {
+    Throw "🛑 dotnet-ef not found on the PATH. Install it with 'dotnet tool install --global dotnet-ef' and make sure the .NET global tools folder is on your PATH."
+    Exit
+}
+
+$efversion = (dotnet-ef --version | Select-Object -Last 1).Trim()
+
+if(!$efversion.StartsWith('10.')) {
+    Throw "🛑 dotnet-ef 10 not installed. Update it with 'dotnet tool update --global dotnet-ef' and re-run the script."
+    Exit
+}
+
 #endregion
 
 

--- a/deployment/Upgrade.ps1
+++ b/deployment/Upgrade.ps1
@@ -36,6 +36,18 @@ if ($response -ne 'Y' -and $response -ne 'y') {
 Write-Host "Thank you for agreeing. Proceeding with the script..." -ForegroundColor Green
 
 
+#region pre-checks
+
+# check if dotnet-ef is installed and on the PATH
+
+if(!(Get-Command dotnet-ef -ErrorAction SilentlyContinue)) {
+    Throw "🛑 dotnet-ef not found on the PATH. Install it with 'dotnet tool install --global dotnet-ef' and make sure the .NET global tools folder is on your PATH."
+    Exit
+}
+
+#endregion
+
+
 #Get TenantID if not set as argument
 	$currentContext = az account show | ConvertFrom-Json
 	$currentTenant = $currentContext.tenantId

--- a/docs/Advanced-Instructions.md
+++ b/docs/Advanced-Instructions.md
@@ -40,7 +40,7 @@ Please note: the SaaS Accelerator is community-supported. If you need help or ha
 wget https://dot.net/v1/dotnet-install.sh -O dotnet-install.sh; `
 chmod +x dotnet-install.sh; `
 ./dotnet-install.sh -version 10.0.400; `
-$ENV:PATH="$HOME/.dotnet:$ENV:PATH"; `
+$ENV:PATH="$HOME/.dotnet:$HOME/.dotnet/tools:$ENV:PATH"; `
 dotnet tool install --global dotnet-ef --version 10.0.11; `
 git clone https://github.com/Azure/Commercial-Marketplace-SaaS-Accelerator.git -b 10.0.0 --depth 1; `
 cd ./Commercial-Marketplace-SaaS-Accelerator/deployment; `

--- a/docs/Installation-Instructions.md
+++ b/docs/Installation-Instructions.md
@@ -37,7 +37,7 @@ Copy the following section to an editor and update it to match your company pref
 wget https://dot.net/v1/dotnet-install.sh -O dotnet-install.sh; `
 chmod +x dotnet-install.sh; `
 ./dotnet-install.sh -version 10.0.400; `
-$ENV:PATH="$HOME/.dotnet:$ENV:PATH"; `
+$ENV:PATH="$HOME/.dotnet:$HOME/.dotnet/tools:$ENV:PATH"; `
 dotnet tool install --global dotnet-ef --version 10.0.11; `
 git clone https://github.com/Azure/Commercial-Marketplace-SaaS-Accelerator.git -b 10.0.0 --depth 1; `
 cd ./Commercial-Marketplace-SaaS-Accelerator/deployment; `
@@ -84,7 +84,7 @@ If you already have deployed the SaaS Accelerator, but you want to update it so 
 wget https://dot.net/v1/dotnet-install.sh -O dotnet-install.sh; `
 chmod +x dotnet-install.sh; `
 ./dotnet-install.sh -version 10.0.400; `
-$ENV:PATH="$HOME/.dotnet:$ENV:PATH"; `
+$ENV:PATH="$HOME/.dotnet:$HOME/.dotnet/tools:$ENV:PATH"; `
 dotnet tool update --global dotnet-ef --version 10.0.11; `
 git clone https://github.com/Azure/Commercial-Marketplace-SaaS-Accelerator.git -b <release-version-branch-to-deploy> --depth 1; `
 cd ./Commercial-Marketplace-SaaS-Accelerator/deployment; `


### PR DESCRIPTION
## Problem

The Cloud Shell install snippets install `dotnet-ef` as a global tool, but only put `$HOME/.dotnet` on `PATH`:

```powershell
$ENV:PATH="$HOME/.dotnet:$ENV:PATH"; `
dotnet tool install --global dotnet-ef --version 10.0.11; `
```

.NET global tools install to `$HOME/.dotnet/tools`, which is never added. The SDK resolves, so the `dotnet --version` pre-check at `Deploy.ps1:206` passes and deployment proceeds normally — until `Deploy.ps1:584` invokes `dotnet-ef` directly:

```
📜 Deploy Code
   🔵 Deploy Database
      ➡️ Generate SQL schema/data script
Deploy.ps1:
Line |
   8 |  .\Deploy.ps1 `
     |  ~~~~~~~~~~~~~~
     | The term 'dotnet-ef' is not recognized as a name of a cmdlet, function, script file, or executable program.
```

By that point the resource group, VNet, SQL server, Key Vault, App Service plan and both web apps already exist. Recovering is awkward: `Deploy.ps1` only skips `az ad app create` when `-ADApplicationID` is supplied, and the client secret is never printed, so a re-run creates a second set of app registrations that have to be cleaned up by hand.

Reproduced by copy-pasting the documented snippet verbatim into Azure Cloud Shell (PowerShell), tag `10.0.0`.

## Changes

- Add `$HOME/.dotnet/tools` to `PATH` in all three documented snippets (`Installation-Instructions.md` install and upgrade, `Advanced-Instructions.md`).
- `Deploy.ps1`: check for `dotnet-ef` and assert a 10.x tool version in the existing `#region pre-checks`, next to the dotnet SDK check — so this fails before `az group create` rather than halfway through.
- `Upgrade.ps1`: same failure exists at lines 109/157 and the script had no pre-checks at all; added a presence check. Presence only, no version assertion — the docs note that upgrading to an older release requires that release's `dotnet-ef` version, so pinning 10.x there would break that path.

## Verification

- Both scripts parse clean: `[System.Management.Automation.Language.Parser]::ParseFile` reports no errors.
- With `dotnet-ef` off `PATH`, `Deploy.ps1` now stops in pre-checks with an actionable message and creates no Azure resources.
- With the corrected `PATH` line, the documented one-liner completes the database step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012r2Y2wFNNk7vGhwxvpPBu6
